### PR TITLE
chore: fix flake on MacOS (systemd dep); move from nixos-unstable to nixos-24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1738843498,
+        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -8,28 +8,27 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        nativeBuildInputs = [
-          # systemd provides libudev for `npm:usb` because of Solana adapter on Hyperlane
+        lib = pkgs.lib;
+        nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [
+          # `systemd` provides libudev for `npm:usb` because of Solana adapter on
+          # Hyperlane, we should enable it only on Linux
           pkgs.systemd
         ];
         buildInputs = [
+          # Node.js
           pkgs.nodejs_20
           pkgs.pnpm
         ];
         shellPkgs = [
-          # # Git LFS
-          # pkgs.git-lfs
           # Run project-specific commands
           pkgs.just
           # Run Github actions locally
           pkgs.act
         ];
-      in
-      {
+      in {
         devShell = pkgs.mkShell {
           inherit nativeBuildInputs buildInputs;
           packages = shellPkgs;
         };
-      }
-    );
+      });
 }


### PR DESCRIPTION
`systemd` package is being used on LInux to serve USB to some npm package that the Hyperlane bridge depends on, but needs to be disabled on MacOS.

Our other repos are using `nixos-24.11`, so I'm setting that as input here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build environment to use a stable dependency source.
  - Refined the setup to automatically include certain tools on Linux.
  - Upgraded developer utilities by integrating newer versions of Node.js and the package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->