### PR TITLE
docs: fix just installation guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ tooling
 
 - **Node.js** - `20.16.0` or higher.
 - **pnpm** - `9.7.1` or higher.
-- **just** - `20.10.7` or higher, [installation guide](https://github.com/baryshev/just).
+- **just** - `20.10.7` or higher, [installation guide](https://github.com/casey/just?tab=readme-ov-file#installation).
 - **Text editor** - We recommend using [VSCode](https://code.visualstudio.com/).
 
 ## Get it running


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to correct the URL for the "just" installation guide, ensuring it now points to the official source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->