### PR TITLE
docs: add JSDoc documentation style guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,154 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+Torus Network TypeScript monorepo built with Turborepo and pnpm. Contains web
+applications, services, and shared packages for the Torus Network ecosystem.
+
+### Architecture Components
+
+- **Apps**: User-facing web applications
+  - Allocator, Wallet, Bridge, Governance, Page
+- **Services**: Backend services
+  - cache, worker
+- **Packages**: Shared libraries
+  - SDK, UI components, utilities, API, database
+- **Tooling**: Development configuration
+  - ESLint, Prettier, TypeScript, Tailwind
+
+The SDK (`@torus-network/sdk`) is the core library for interacting with the
+Torus Network blockchain, providing Substrate/Polkadot.js abstractions.
+
+## Essential Commands
+
+### Development Workflow
+
+```sh
+# Install dependencies
+just install
+# or: pnpm install
+
+# Build everything
+just build
+
+# Setup database (required for Allocator and Governance apps)
+just db-push
+
+# Start development server for specific app
+just dev torus-wallet
+just dev torus-allocator
+just dev torus-governance
+just dev torus-bridge
+just dev torus-page
+
+# Watch mode development
+just dev-watch torus-wallet
+```
+
+### Code Quality
+
+```sh
+# Run all checks (typecheck + lint)
+just check-all
+
+# Check specific package
+just check "@torus-network/sdk"
+
+# Fix formatting and linting
+just fix
+
+# Individual operations
+just typecheck
+just lint
+just format
+```
+
+### Testing
+
+```sh
+# Test specific package
+just test "@torus-network/torus-utils"
+just test "torus-allocator"
+
+# Test all packages
+just test
+```
+
+### Database Operations
+
+```sh
+# Push schema changes
+just db-push
+
+# Open database studio
+just db-studio
+
+# Export database dump
+just db-dump
+```
+
+## Development Guidelines
+
+### Package Targeting
+
+When making changes, target specific packages for faster feedback:
+
+- Format: `just format-fix "@torus-ts/utils"`
+- Lint: `just lint-fix "@torus-ts/utils"`
+- Test: `just test "@torus-network/torus-utils"`
+
+### Error Handling Priorities
+
+1. Typecheck errors must be addressed first
+2. Fix linting errors in modified packages
+3. Format errors only need fixing in modified packages
+4. Ignore formatting/linting errors in unmodified packages
+
+### Package Names
+
+Key packages use different naming patterns:
+
+- `@torus-network/sdk` - Main SDK package
+- `@torus-network/torus-utils` - Utilities package
+- `@torus-ts/*` - Internal workspace packages
+- Apps use simple names: `torus-wallet`, `torus-allocator`, etc.
+
+## Project Structure Insights
+
+### Dependencies & Build Order
+
+- Packages must build before apps (enforced by Turborepo)
+- SDK requires subspace package for type generation
+- Apps depend on shared packages (@torus-ts/ui, @torus-ts/api, etc.)
+
+### Environment Setup
+
+- Environment variables are shared across the monorepo
+- Use `.env` file in root directory
+- Database connection required for Allocator and Governance apps
+- Multiple blockchain environment configurations supported
+
+### Technology Stack
+
+- **Frontend**: Next.js with React 19, Tailwind CSS, tRPC
+- **Backend**: Node.js services, Drizzle ORM, PostgreSQL
+- **Blockchain**: Polkadot.js API, custom Substrate integration
+- **Development**: Turborepo, pnpm workspaces, Just task runner
+
+## Documentation
+
+### JSDoc Standards
+
+Follow the project's [@docs/DOCUMENTATION_STYLE.md](./docs/DOCUMENTATION_STYLE.md) for all code documentation.
+
+### Markdown
+
+- Use `sh` instead of `bash` when sharing code block snippets.
+- Use `ts` instead of `typescript` when sharing code block snippets.
+
+## Branching
+
+- We should create new branches over `dev` branch

--- a/docs/DOCUMENTATION_STYLE.md
+++ b/docs/DOCUMENTATION_STYLE.md
@@ -1,0 +1,167 @@
+# Documentation Style Guide
+
+This document defines the JSDoc documentation standards for the Torus TypeScript monorepo.
+
+## General Principles
+
+1. **Avoid Redundancy**: Don't document what TypeScript already makes clear
+2. **Focus on Intent**: Explain *why* and *how*, not just *what*
+3. **Practical Examples**: Show real-world usage patterns
+4. **Consistency**: Follow the same patterns across all packages
+
+## JSDoc Standards
+
+### When to Document Return Types
+
+**Skip `@returns` when the return type is obvious from TypeScript:**
+
+```ts
+// ❌ Redundant - TypeScript already shows this returns ErrorArray
+/**
+ * Creates an ErrorArray from an array of errors.
+ * @param errors - Array of Error objects to aggregate
+ * @returns A new ErrorArray instance containing the provided errors
+ */
+static from(errors: Error[]): ErrorArray
+
+// ✅ Better - focus on behavior and usage
+/**
+ * Creates an ErrorArray from an array of errors.
+ * @param errors - Array of Error objects to aggregate
+ */
+static from(errors: Error[]): ErrorArray
+```
+
+**Include `@returns` when the behavior isn't obvious:**
+
+```ts
+// ✅ Good - explains the Result tuple behavior
+/**
+ * Handles synchronous operations with Go-style error handling.
+ * @param syncOperation - A synchronous function that might throw
+ * @returns A tuple with [error or undefined, data or undefined]
+ */
+export function trySync<T>(syncOperation: () => T): Result<T, Error>
+```
+
+### Classes
+
+Focus on purpose, behavior, and usage patterns:
+
+```ts
+/**
+ * A class that aggregates multiple errors into a single error-like object.
+ * 
+ * Extends Array<Error> and implements the Error interface, allowing it to be
+ * used both as a collection of errors and as a single error object.
+ * 
+ * @example
+ * ```ts
+ * const errors = [new Error('Field A invalid'), new Error('Field B required')];
+ * const errorArray = new ErrorArray(errors);
+ * 
+ * // Use as Error
+ * throw errorArray; // Works like any Error
+ * 
+ * // Use as Array
+ * errorArray.forEach(err => console.log(err.message));
+ * ```
+ */
+export class ErrorArray extends Array<Error> implements MultiError {
+```
+
+### Types and Interfaces
+
+Keep descriptions concise and focus on purpose:
+
+```ts
+/**
+ * Combines Error and Array<Error> interfaces for dual-purpose error handling.
+ */
+export type MultiError = Error & Error[];
+
+/**
+ * Configuration for customizing ErrorArray behavior.
+ */
+interface ErrorArrayConfig {
+  /** Override the default combined message */
+  message?: string;
+  /** Override the default combined name */  
+  name?: string;
+}
+```
+
+### Methods and Functions
+
+Focus on behavior and usage. Skip redundant return type documentation:
+
+```ts
+// ✅ Good - focuses on what it does and when to use it
+/**
+ * Type guard to check if a value is an instance of Error.
+ * @param error - The value to check
+ * @example
+ * ```ts
+ * if (isError(result)) {
+ *   console.error(result.message);
+ * }
+ * ```
+ */
+export function isError(error: unknown): error is Error
+
+// ❌ Avoid - redundant return documentation
+/**
+ * Type guard to check if a value is an instance of Error.
+ * @param error - The value to check
+ * @returns True if the value is an Error instance, false otherwise
+ */
+export function isError(error: unknown): error is Error
+```
+
+For complex functions, explain non-obvious behavior:
+
+```ts
+/**
+ * Ensures that the provided value is converted to an Error object.
+ * 
+ * If the input is already an Error, returns it unchanged. Otherwise, attempts
+ * to create a new Error with a stringified version of the input.
+ * 
+ * @param maybeError - The value to convert to an Error
+ * @example
+ * ```ts
+ * // Returns original error
+ * ensureError(new Error('test')); // Error: test
+ * 
+ * // Converts object to Error  
+ * ensureError({ message: 'test' }); // Error: {"message":"test"}
+ * ```
+ */
+export function ensureError(maybeError: unknown): Error
+```
+
+## Best Practices
+
+### Examples
+
+- Use realistic, practical scenarios
+- Keep examples concise but complete
+- Show the most common usage patterns first
+- Include edge cases when relevant
+
+### Parameter Documentation
+
+- Focus on purpose and expected format
+- Skip obvious type information (TypeScript handles this)
+- Mark optional parameters when behavior changes significantly
+- Explain constraints and validation requirements
+
+### When to Skip Documentation
+
+- Simple getters/setters with obvious behavior
+
+### Code Quality
+
+- Ensure all code examples are syntactically correct
+- Use consistent naming in examples
+- Include necessary imports only when not obvious

--- a/packages/db/creating-items-in-database.md
+++ b/packages/db/creating-items-in-database.md
@@ -11,7 +11,7 @@ cache related folders and run `pnpm i` again.
 
 First, we define the schema for the module in `packages/db/src/schema.ts`.
 
-```typescript
+```ts
 // Test Table
 export const moduleTest = createTable("module_test", {
   id: serial("id").primaryKey(),
@@ -36,7 +36,7 @@ Remember to run `pnpm db:push` to push the schema to the database.
 
 Next, we define the API routes using tRPC, in this case since we are creating a new module, we will create a new router file in `packages/api/src/router/module-test.ts`.
 
-```typescript
+```ts
 export const moduleTestRouter = {
   // Get the latest module
   getLatest: publicProcedure.query(({ ctx }) => {
@@ -62,7 +62,7 @@ export const moduleTestRouter = {
 
 We then combine the individual routers into a root router in `packages/api/src/root.ts`.
 
-```typescript
+```ts
 export const appRouter = createTRPCRouter({
   moduleTest: moduleTestRouter, // We add the moduleTestRouter here
   module: moduleRouter,
@@ -75,7 +75,7 @@ export const appRouter = createTRPCRouter({
 
 We create the main page component in `apps/torus-allocator/src/app/page.tsx`.
 
-```typescript
+```ts
 export default function Page() {
   return <CrudShowcase />;
 }
@@ -106,7 +106,7 @@ async function CrudShowcase() {
 Lastly, we create a form component for adding new items in
 `apps/torus-allocator/src/app/components/create-module-test.tsx`.
 
-```typescript
+```ts
 export function CreateWeight() {
   const router = useRouter();
   const [weight, setWeight] = useState<number>(0);

--- a/packages/torus-sdk-ts/README.md
+++ b/packages/torus-sdk-ts/README.md
@@ -30,7 +30,7 @@ This SDK provides a comprehensive set of tools and utilities to interact with th
 
 ### Connection Setup
 
-```typescript
+```ts
 import { setup } from "@torus-network/sdk";
 
 // Connect to a Torus node
@@ -50,7 +50,7 @@ The SDK is organized into modules for different parts of the Torus ecosystem:
 
 **Query Balance**
 
-```typescript
+```ts
 import { queryFreeBalance } from "@torus-network/sdk";
 
 const balance = await queryFreeBalance(api, "your-ss58-address");
@@ -59,7 +59,7 @@ console.log(`Current balance: ${balance}`);
 
 **Query Agents**
 
-```typescript
+```ts
 import { queryAgents } from "@torus-network/sdk";
 
 const agents = await queryAgents(api);
@@ -68,7 +68,7 @@ console.log(`Found ${agents.size} agents`);
 
 **Working with Governance**
 
-```typescript
+```ts
 import { queryProposals } from "@torus-network/sdk";
 
 const proposals = await queryProposals(api);

--- a/packages/utils/src/try-catch.ts
+++ b/packages/utils/src/try-catch.ts
@@ -30,7 +30,7 @@ export function isError(error: unknown): error is Error {
  * @returns An Error object
  *
  * @example
- * ```typescript
+ * ```ts
  * // Returns original error
  * ensureError(new Error('test')); // Error: test
  *
@@ -136,7 +136,7 @@ export function tryAsyncRaw<T, E>(
  * @returns An AsyncResultObj containing success or Error.
  *
  * @example
- * ```typescript
+ * ```ts
  * const result = await tryAsync(fetch('https://api.example.com/data'))
  *   .match({
  *     Ok: (data) => console.log('API data:', data),


### PR DESCRIPTION
## Summary

- Creates comprehensive JSDoc documentation style guide for the TypeScript monorepo
- Establishes standards for avoiding redundancy with TypeScript's type information
- Provides examples for documenting classes, functions, types, and best practices
- Updates CLAUDE.md to reference the new style guide for easy access

## Test plan

- [x] Review documentation style guide for completeness
- [x] Verify CLAUDE.md properly references the style guide with @ symbol
- [x] Ensure examples in style guide are syntactically correct
- [x] Confirm guidelines align with project conventions

🤖 Generated with [Claude Code](https://claude.ai/code)