### PR TITLE
fix issues in Edit Agent form and improve UX handling (web-222)

### DIFF
--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
@@ -85,11 +85,7 @@ export const updateAgentSchema = z.object({
     .trim()
     .min(1, "Short description is required")
     .max(200, "Short description cannot exceed 200 characters"),
-  description: z
-    .string()
-    .trim()
-    .min(1, "Description is required")
-    .max(5000, "Description cannot exceed 5000 characters"),
+  description: z.string().trim().min(1, "Description is required"),
   website: z
     .string()
     .trim()

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
@@ -137,7 +137,7 @@ export interface MetadataType {
 export interface UpdateAgentMutation {
   isPending: boolean;
   mutate: (data: UpdateAgentFormData) => void;
-  handleImageChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export type UpdateAgentForm = UseFormReturn<UpdateAgentFormData>;

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
@@ -27,13 +27,8 @@ const ensureHttpsProtocol = (val: string | undefined): string => {
   return `https://${cleanedVal}`;
 };
 
-export const MAX_FILE_SIZE = 512000; // 512KB
-export const ACCEPTED_FILE_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-];
+export const MAX_FILE_SIZE = 512_000; // 512KB
+export const ACCEPTED_FILE_TYPES = ["png", "jpg", "jpeg", "gif", "webp"];
 
 export const updateAgentSocialsSchema = z.object({
   twitter: z
@@ -106,9 +101,12 @@ export const updateAgentSchema = z.object({
     .refine((file) => file.size <= MAX_FILE_SIZE, {
       message: `File size must be less than ${(MAX_FILE_SIZE / 1000).toFixed(0)}KB`,
     })
-    .refine((file) => ACCEPTED_FILE_TYPES.includes(file.type), {
-      message: "File must be PNG, JPEG, GIF, or WebP format",
-    })
+    .refine(
+      (file) => ACCEPTED_FILE_TYPES.includes(file.type.split("/")[1] ?? ""),
+      {
+        message: `File must be ${ACCEPTED_FILE_TYPES.join(", ")} format`,
+      },
+    )
     .optional(),
   socials: updateAgentSocialsSchema,
 });

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
@@ -81,7 +81,11 @@ export const updateAgentSchema = z.object({
     .trim()
     .min(1, "Short description is required")
     .max(200, "Short description cannot exceed 200 characters"),
-  description: z.string().trim().min(1, "Description is required"),
+  description: z
+    .string()
+    .trim()
+    .min(1, "Description is required")
+    .max(50_000, "Description must be less than 50,000 characters"),
   website: z
     .string()
     .trim()

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form-schema.ts
@@ -104,13 +104,7 @@ export const updateAgentSchema = z.object({
       message: "Must be a valid URL",
     })
     .optional(),
-  imageUrl: z
-    .string()
-    .trim()
-    .refine((val) => !val || z.string().url().safeParse(val).success, {
-      message: "Must be a valid URL",
-    })
-    .optional(),
+  imageFile: z.instanceof(File).optional(),
   socials: updateAgentSocialsSchema,
 });
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -159,7 +159,7 @@ export function UpdateAgentDialogForm({
                     {...field}
                     placeholder="Ex.: ## About This Agent
 This agent specializes in providing technical support by analyzing issues and offering step-by-step solutions. It can help with software troubleshooting, guide users through complex processes, and learn from interactions."
-                    maxLength={5000}
+                    maxLength={50_000}
                     rows={6}
                     className="resize-y"
                   />

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -24,13 +24,11 @@ interface UpdateAgentDialogFormProps {
   setActiveTab: (tab: string) => void;
   setIsOpen?: (isOpen: boolean) => void;
   form: UpdateAgentForm;
-  imageFile: File | null;
 }
 
 export function UpdateAgentDialogForm({
   updateAgentMutation,
   form,
-  imageFile,
 }: UpdateAgentDialogFormProps) {
   const onSubmit = (data: UpdateAgentFormData) => {
     void updateAgentMutation.mutate({
@@ -210,13 +208,10 @@ This agent specializes in providing technical support by analyzing issues and of
                     <FormMessage />
                   </div>
 
-                  {(field.value ?? imageFile) && (
+                  {field.value && (
                     <div className="rounded-md overflow-hidden w-24 h-24 border flex-shrink-0 bg-muted">
                       <Image
-                        src={
-                          field.value ??
-                          (imageFile ? URL.createObjectURL(imageFile) : "")
-                        }
+                        src={field.value || ""}
                         alt="Agent Icon Preview"
                         className="w-full h-full object-cover"
                         width={256}

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -45,6 +45,8 @@ export function UpdateAgentDialogForm({
     });
   };
 
+  const acceptedFileTypesMessage = `File must be ${ACCEPTED_FILE_TYPES.map((aft) => aft.toUpperCase()).join(", ")} format`;
+
   const onChangeImageFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
 
@@ -60,16 +62,14 @@ export function UpdateAgentDialogForm({
       return;
     }
 
-    const isValidType = Object.keys(ACCEPTED_FILE_TYPES).includes(file.type);
-    if (!isValidType) {
+    if (!ACCEPTED_FILE_TYPES.includes(file.type.split("/")[1] ?? "")) {
       form.setError("imageFile", {
         type: "manual",
-        message: "File must be PNG, JPEG, GIF, or WebP format",
+        message: acceptedFileTypesMessage,
       });
       return;
     }
 
-    form.clearErrors("imageFile");
     updateAgentMutation.handleImageChange(e);
   };
 
@@ -231,15 +231,15 @@ This agent specializes in providing technical support by analyzing issues and of
                     <FormControl>
                       <Input
                         type="file"
-                        accept={Object.keys(ACCEPTED_FILE_TYPES).join(",")}
+                        accept={`image/${ACCEPTED_FILE_TYPES.join(",image/")}`}
                         onChange={onChangeImageFile}
                         className="cursor-pointer"
                       />
                     </FormControl>
                     <p className="text-xs text-muted-foreground mt-1">
                       Square Image (Max 512x512) • Max{" "}
-                      {(MAX_FILE_SIZE / 1000).toFixed(0)}KB • PNG, JPEG, GIF,
-                      WebP
+                      {(MAX_FILE_SIZE / 1000).toFixed(0)}KB •{" "}
+                      {acceptedFileTypesMessage}
                     </p>
                     <FormMessage />
                   </div>

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -16,7 +16,11 @@ import type {
   UpdateAgentFormData,
   UpdateAgentMutation,
 } from "./update-agent-dialog-form-schema";
-import { updateAgentSchema } from "./update-agent-dialog-form-schema";
+import {
+  ACCEPTED_FILE_TYPES,
+  MAX_FILE_SIZE,
+  updateAgentSchema,
+} from "./update-agent-dialog-form-schema";
 
 interface UpdateAgentDialogFormProps {
   agentKey: string;
@@ -39,6 +43,34 @@ export function UpdateAgentDialogForm({
     void updateAgentMutation.mutate({
       ...data,
     });
+  };
+
+  const onChangeImageFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      form.setError("imageFile", {
+        type: "manual",
+        message: `File size must be less than ${(MAX_FILE_SIZE / 1000).toFixed(0)}KB`,
+      });
+      return;
+    }
+
+    const isValidType = Object.keys(ACCEPTED_FILE_TYPES).includes(file.type);
+    if (!isValidType) {
+      form.setError("imageFile", {
+        type: "manual",
+        message: "File must be PNG, JPEG, GIF, or WebP format",
+      });
+      return;
+    }
+
+    form.clearErrors("imageFile");
+    updateAgentMutation.handleImageChange(e);
   };
 
   return (
@@ -199,13 +231,15 @@ This agent specializes in providing technical support by analyzing issues and of
                     <FormControl>
                       <Input
                         type="file"
-                        accept="image/*"
-                        onChange={updateAgentMutation.handleImageChange}
+                        accept={Object.keys(ACCEPTED_FILE_TYPES).join(",")}
+                        onChange={onChangeImageFile}
                         className="cursor-pointer"
                       />
                     </FormControl>
                     <p className="text-xs text-muted-foreground mt-1">
-                      Recommended size: 256x256px
+                      Square Image (Max 512x512) • Max{" "}
+                      {(MAX_FILE_SIZE / 1000).toFixed(0)}KB • PNG, JPEG, GIF,
+                      WebP
                     </p>
                     <FormMessage />
                   </div>

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -216,7 +216,7 @@ This agent specializes in providing technical support by analyzing issues and of
                         src={
                           field.value
                             ? URL.createObjectURL(field.value)
-                            : currentImagePreview!
+                            : (currentImagePreview ?? "")
                         }
                         alt="Agent Icon Preview"
                         className="w-full h-full object-cover"

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -32,6 +32,9 @@ export function UpdateAgentDialogForm({
   form,
   currentImagePreview,
 }: UpdateAgentDialogFormProps) {
+  const imageFile = form.watch("imageFile");
+  const imageBlobUrl = imageFile ? URL.createObjectURL(imageFile) : null;
+
   const onSubmit = (data: UpdateAgentFormData) => {
     void updateAgentMutation.mutate({
       ...data,
@@ -212,7 +215,7 @@ This agent specializes in providing technical support by analyzing issues and of
                       <Image
                         src={
                           field.value
-                            ? URL.createObjectURL(field.value)
+                            ? (imageBlobUrl ?? "")
                             : (currentImagePreview ?? "")
                         }
                         alt="Agent Icon Preview"

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -24,11 +24,13 @@ interface UpdateAgentDialogFormProps {
   setActiveTab: (tab: string) => void;
   setIsOpen?: (isOpen: boolean) => void;
   form: UpdateAgentForm;
+  currentImagePreview?: string | null;
 }
 
 export function UpdateAgentDialogForm({
   updateAgentMutation,
   form,
+  currentImagePreview,
 }: UpdateAgentDialogFormProps) {
   const onSubmit = (data: UpdateAgentFormData) => {
     void updateAgentMutation.mutate({
@@ -183,7 +185,7 @@ This agent specializes in providing technical support by analyzing issues and of
 
           <FormField
             control={form.control}
-            name="imageUrl"
+            name="imageFile"
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="flex items-center gap-2">
@@ -208,10 +210,14 @@ This agent specializes in providing technical support by analyzing issues and of
                     <FormMessage />
                   </div>
 
-                  {field.value && (
+                  {(field.value || currentImagePreview) && (
                     <div className="rounded-md overflow-hidden w-24 h-24 border flex-shrink-0 bg-muted">
                       <Image
-                        src={field.value || ""}
+                        src={
+                          field.value
+                            ? URL.createObjectURL(field.value)
+                            : currentImagePreview!
+                        }
                         alt="Agent Icon Preview"
                         className="w-full h-full object-cover"
                         width={256}

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -70,6 +70,7 @@ export function UpdateAgentDialogForm({
       return;
     }
 
+    form.clearErrors("imageFile");
     updateAgentMutation.handleImageChange(e);
   };
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-form.tsx
@@ -197,10 +197,7 @@ This agent specializes in providing technical support by analyzing issues and of
                       <Input
                         type="file"
                         accept="image/*"
-                        onChange={(e) =>
-                          updateAgentMutation.handleImageChange &&
-                          updateAgentMutation.handleImageChange(e)
-                        }
+                        onChange={updateAgentMutation.handleImageChange}
                         className="cursor-pointer"
                       />
                     </FormControl>
@@ -210,7 +207,7 @@ This agent specializes in providing technical support by analyzing issues and of
                     <FormMessage />
                   </div>
 
-                  {(field.value || currentImagePreview) && (
+                  {(field.value ?? currentImagePreview) && (
                     <div className="rounded-md overflow-hidden w-24 h-24 border flex-shrink-0 bg-muted">
                       <Image
                         src={

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-preview.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-preview.tsx
@@ -4,6 +4,7 @@ import { Card } from "@torus-ts/ui/components/card";
 import { AgentCardContent } from "~/app/_components/agent-card/agent-card-content";
 import type { AgentHeaderProps } from "~/app/_components/agent-card/agent-card-header";
 import { AgentCardHeader } from "~/app/_components/agent-card/agent-card-header";
+import { useBlobUrl } from "~/hooks/use-blob-url";
 import { api } from "~/trpc/react";
 import type { UpdateAgentForm } from "./update-agent-dialog-form-schema";
 
@@ -43,6 +44,7 @@ export function UpdateAgentDialogPreview({
 
   const formValues = form.getValues();
   const previewImage = form.watch("imageFile");
+  const previewImageBlobUrl = useBlobUrl(previewImage);
 
   const headerProps: AgentHeaderProps = {
     name: formValues.name ?? "",
@@ -61,7 +63,7 @@ export function UpdateAgentDialogPreview({
         telegram: formValues.socials.telegram,
       },
       website: formValues.website,
-      iconUrl: previewImage ? URL.createObjectURL(previewImage) : undefined,
+      iconUrl: previewImageBlobUrl ?? undefined,
     },
   };
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-preview.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-preview.tsx
@@ -38,13 +38,13 @@ export function UpdateAgentDialogPreview({
     },
   );
 
-  if (isLoading || !agent?.metadataUri) {
-    return <AgentPreviewSkeleton />;
-  }
-
   const formValues = form.getValues();
   const previewImage = form.watch("imageFile");
   const previewImageBlobUrl = useBlobUrl(previewImage);
+
+  if (isLoading || !agent?.metadataUri) {
+    return <AgentPreviewSkeleton />;
+  }
 
   const headerProps: AgentHeaderProps = {
     name: formValues.name ?? "",

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-preview.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-preview.tsx
@@ -42,7 +42,7 @@ export function UpdateAgentDialogPreview({
   }
 
   const formValues = form.getValues();
-  const previewImage = form.watch("imageUrl");
+  const previewImage = form.watch("imageFile");
 
   const headerProps: AgentHeaderProps = {
     name: formValues.name ?? "",
@@ -61,7 +61,7 @@ export function UpdateAgentDialogPreview({
         telegram: formValues.socials.telegram,
       },
       website: formValues.website,
-      iconUrl: previewImage ?? undefined,
+      iconUrl: previewImage ? URL.createObjectURL(previewImage) : undefined,
     },
   };
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-tabs.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-tabs.tsx
@@ -12,7 +12,14 @@ import {
   TabsList,
   TabsTrigger,
 } from "@torus-ts/ui/components/tabs";
-import { ArrowLeft, ArrowRight, Eye, LoaderCircle, Pencil, Save } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Eye,
+  LoaderCircle,
+  Pencil,
+  Save,
+} from "lucide-react";
 import { useState } from "react";
 import { UpdateAgentDialogForm } from "./update-agent-dialog-form";
 import type {
@@ -25,12 +32,14 @@ interface UpdateAgentDialogTabsProps {
   agentKey: string;
   form: UpdateAgentForm;
   updateAgentMutation: UpdateAgentMutation;
+  currentImagePreview?: string | null;
 }
 
 export function UpdateAgentDialogTabs({
   agentKey,
   form,
   updateAgentMutation,
+  currentImagePreview,
 }: UpdateAgentDialogTabsProps) {
   const [activeTab, setActiveTab] = useState("edit");
 
@@ -109,6 +118,7 @@ export function UpdateAgentDialogTabs({
                 setActiveTab={setActiveTab}
                 form={form}
                 updateAgentMutation={updateAgentMutation}
+                currentImagePreview={currentImagePreview}
               />
             </div>
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-tabs.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-tabs.tsx
@@ -25,14 +25,12 @@ interface UpdateAgentDialogTabsProps {
   agentKey: string;
   form: UpdateAgentForm;
   updateAgentMutation: UpdateAgentMutation;
-  imageFile: File | null;
 }
 
 export function UpdateAgentDialogTabs({
   agentKey,
   form,
   updateAgentMutation,
-  imageFile,
 }: UpdateAgentDialogTabsProps) {
   const [activeTab, setActiveTab] = useState("edit");
 
@@ -111,7 +109,6 @@ export function UpdateAgentDialogTabs({
                 setActiveTab={setActiveTab}
                 form={form}
                 updateAgentMutation={updateAgentMutation}
-                imageFile={imageFile}
               />
             </div>
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-tabs.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-tabs.tsx
@@ -12,7 +12,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@torus-ts/ui/components/tabs";
-import { ArrowLeft, ArrowRight, Eye, Pencil, Save } from "lucide-react";
+import { ArrowLeft, ArrowRight, Eye, LoaderCircle, Pencil, Save } from "lucide-react";
 import { useState } from "react";
 import { UpdateAgentDialogForm } from "./update-agent-dialog-form";
 import type {
@@ -91,11 +91,11 @@ export function UpdateAgentDialogTabs({
         className="mt-6 w-full"
       >
         <TabsList className="grid w-full grid-cols-2 mb-6">
-          <TabsTrigger value="edit">
+          <TabsTrigger value="edit" disabled={updateAgentMutation.isPending}>
             <Pencil className="h-4 w-4 mr-2" />
             <span>Edit Details</span>
           </TabsTrigger>
-          <TabsTrigger value="preview">
+          <TabsTrigger value="preview" disabled={updateAgentMutation.isPending}>
             <Eye className="h-4 w-4 mr-2" />
             <span>Preview</span>
           </TabsTrigger>
@@ -152,8 +152,13 @@ export function UpdateAgentDialogTabs({
                 variant="outline"
                 onClick={handleSubmit}
                 disabled={updateAgentMutation.isPending}
+                className="flex items-center gap-2"
               >
-                <Save className="h-4 w-4" />
+                {updateAgentMutation.isPending ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
                 {updateAgentMutation.isPending ? "Saving..." : "Save Changes"}
               </Button>
             </div>

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-util.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-util.ts
@@ -30,25 +30,29 @@ export const blobUrlToFile = async (
   return new File([blob], filename, { type: blob.type });
 };
 
+const getIconCid = async (
+  metadata: UpdateAgentFormData,
+  currentImageBlobUrl?: string,
+): Promise<string | undefined> => {
+  if (metadata.imageFile) {
+    const { cid } = await pinFile(metadata.imageFile);
+    return cidToIpfsUri(cid);
+  }
+
+  if (currentImageBlobUrl) {
+    const file = await blobUrlToFile(currentImageBlobUrl, "agent-icon.png");
+    const { cid } = await pinFile(file);
+    return cidToIpfsUri(cid);
+  }
+
+  return undefined;
+};
+
 export const uploadMetadata = async (
   metadata: UpdateAgentFormData,
   currentImageBlobUrl?: string,
 ): Promise<string> => {
-  let icon: string | undefined;
-
-  if (metadata.imageFile) {
-    // New image file selected
-    const { cid } = await pinFile(metadata.imageFile);
-    icon = cidToIpfsUri(cid);
-  } else if (currentImageBlobUrl) {
-    // Use existing image from blob URL
-    const imageFile = await blobUrlToFile(
-      currentImageBlobUrl,
-      "agent-icon.png",
-    );
-    const { cid } = await pinFile(imageFile);
-    icon = cidToIpfsUri(cid);
-  }
+  const icon = await getIconCid(metadata, currentImageBlobUrl);
 
   const images = icon ? { icon } : undefined;
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-util.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-util.ts
@@ -21,10 +21,34 @@ export const pinFile = async (file: File): Promise<{ cid: string }> => {
 
 export const cidToIpfsUri = (cid: string): string => `ipfs://${cid}`;
 
+export const blobUrlToFile = async (
+  blobUrl: string,
+  filename: string,
+): Promise<File> => {
+  const response = await fetch(blobUrl);
+  const blob = await response.blob();
+  return new File([blob], filename, { type: blob.type });
+};
+
 export const uploadMetadata = async (
   metadata: UpdateAgentFormData,
+  currentImageBlobUrl?: string,
 ): Promise<string> => {
-  const icon = metadata.imageUrl;
+  let icon: string | undefined;
+
+  if (metadata.imageFile) {
+    // New image file selected
+    const { cid } = await pinFile(metadata.imageFile);
+    icon = cidToIpfsUri(cid);
+  } else if (currentImageBlobUrl) {
+    // Use existing image from blob URL
+    const imageFile = await blobUrlToFile(
+      currentImageBlobUrl,
+      "agent-icon.png",
+    );
+    const { cid } = await pinFile(imageFile);
+    icon = cidToIpfsUri(cid);
+  }
 
   const images = icon ? { icon } : undefined;
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-util.ts
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog-util.ts
@@ -23,11 +23,8 @@ export const cidToIpfsUri = (cid: string): string => `ipfs://${cid}`;
 
 export const uploadMetadata = async (
   metadata: UpdateAgentFormData,
-  imageFile: File | null,
 ): Promise<string> => {
-  const icon = imageFile
-    ? cidToIpfsUri(await pinFile(imageFile).then(({ cid }) => cid))
-    : undefined;
+  const icon = metadata.imageUrl;
 
   const images = icon ? { icon } : undefined;
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -200,10 +200,14 @@ export default function UpdateAgentDialog({
           callback: (tx) => {
             if (tx.status === "SUCCESS" && !tx.message?.includes("included")) {
               setIsOpen(false);
+              setIsUploading(false);
+            }
+
+            if (tx.status === "ERROR") {
+              setIsUploading(false);
             }
 
             setTransactionStatus(tx);
-            setIsUploading(false);
           },
         });
       },
@@ -227,12 +231,10 @@ export default function UpdateAgentDialog({
         currentImagePreview={currentImagePreview}
       />
       {transactionStatus.status && (
-        <div className="mt-4 border rounded-md p-3 bg-black/5">
-          <TransactionStatus
-            status={transactionStatus.status}
-            message={transactionStatus.message}
-          />
-        </div>
+        <TransactionStatus
+          status={transactionStatus.status}
+          message={transactionStatus.message}
+        />
       )}
       <UnsavedChangesDialog
         open={showConfirmClose}
@@ -241,7 +243,6 @@ export default function UpdateAgentDialog({
         onConfirm={() => {
           setShowConfirmClose(false);
           setIsOpen(false);
-          // Reset to original data instead of empty defaults
           if (originalFormData) {
             form.reset(originalFormData);
           }

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -59,8 +59,19 @@ export default function UpdateAgentDialog({
   const currentImageBlobUrl = useBlobUrl(agentMetadata?.images.icon);
 
   useEffect(() => {
+    if (currentImagePreview && currentImagePreview !== currentImageBlobUrl) {
+      URL.revokeObjectURL(currentImagePreview);
+    }
     setCurrentImagePreview(currentImageBlobUrl);
-  }, [currentImageBlobUrl]);
+  }, [currentImageBlobUrl, currentImagePreview]);
+
+  useEffect(() => {
+    return () => {
+      if (currentImagePreview) {
+        URL.revokeObjectURL(currentImagePreview);
+      }
+    };
+  }, [currentImagePreview]);
 
   const [originalFormData, setOriginalFormData] =
     useState<UpdateAgentFormData | null>(null);

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -62,6 +62,9 @@ export default function UpdateAgentDialog({
     setCurrentImagePreview(currentImageBlobUrl);
   }, [currentImageBlobUrl]);
 
+  const [originalFormData, setOriginalFormData] =
+    useState<UpdateAgentFormData | null>(null);
+
   const form = useForm<UpdateAgentFormData>({
     resolver: zodResolver(updateAgentSchema),
     mode: "onChange",
@@ -109,6 +112,7 @@ export default function UpdateAgentDialog({
         },
       };
 
+      setOriginalFormData(originalData);
       form.reset(originalData);
       setHasUnsavedChanges(false);
     }
@@ -131,15 +135,21 @@ export default function UpdateAgentDialog({
 
         setIsOpen(false);
         form.reset();
+        if (originalFormData) {
+          form.reset(originalFormData);
+        }
         return;
       }
       setIsOpen(open);
       if (!open) {
         form.reset();
+        if (originalFormData) {
+          form.reset(originalFormData);
+        }
         setHasUnsavedChanges(false);
       }
     },
-    [isUploading, setIsOpen, form, hasUnsavedChanges],
+    [isUploading, setIsOpen, form, hasUnsavedChanges, originalFormData],
   );
 
   useEffect(() => {
@@ -220,7 +230,10 @@ export default function UpdateAgentDialog({
         onConfirm={() => {
           setShowConfirmClose(false);
           setIsOpen(false);
-          form.reset();
+          // Reset to original data instead of empty defaults
+          if (originalFormData) {
+            form.reset(originalFormData);
+          }
           setHasUnsavedChanges(false);
         }}
       />

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useTorus } from "@torus-ts/torus-provider";
 import type { TransactionResult } from "@torus-ts/ui/components/transaction-status";
 import { TransactionStatus } from "@torus-ts/ui/components/transaction-status";
+import { useRouter } from "next/navigation";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -27,6 +28,7 @@ export default function UpdateAgentDialog({
   setIsOpen,
   handleDialogChangeRef,
 }: UpdateAgentDialogProps) {
+  const router = useRouter();
   const { updateAgentTransaction } = useTorus();
   const [isUploading, setIsUploading] = useState(false);
   const [showConfirmClose, setShowConfirmClose] = useState(false);
@@ -201,6 +203,7 @@ export default function UpdateAgentDialog({
             if (tx.status === "SUCCESS" && !tx.message?.includes("included")) {
               setIsOpen(false);
               setIsUploading(false);
+              router.refresh();
             }
 
             if (tx.status === "ERROR") {
@@ -219,6 +222,7 @@ export default function UpdateAgentDialog({
       setIsOpen,
       setTransactionStatus,
       currentImageBlobUrl,
+      router,
     ],
   );
 

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -96,6 +96,9 @@ export default function UpdateAgentDialog({
 
   const handleDialogChange = useCallback(
     (open: boolean) => {
+      if (!open && isUploading) {
+        return;
+      }
       if (!open && !isUploading) {
         setShowConfirmClose(true);
         return;

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -14,11 +14,7 @@ import { api } from "~/trpc/react";
 import type { UpdateAgentFormData } from "./update-agent-dialog-form-schema";
 import { updateAgentSchema } from "./update-agent-dialog-form-schema";
 import { UpdateAgentDialogTabs } from "./update-agent-dialog-tabs";
-import {
-  cidToIpfsUri,
-  uploadMetadata,
-  pinFile,
-} from "./update-agent-dialog-util";
+import { cidToIpfsUri, uploadMetadata } from "./update-agent-dialog-util";
 
 interface UpdateAgentDialogProps {
   agentKey: string;

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/components/update-agent-button/update-agent-dialog/update-agent-dialog.tsx
@@ -83,7 +83,7 @@ export default function UpdateAgentDialog({
   });
 
   useEffect(() => {
-    const subscription = form.watch((value, { name, type }) => {
+    const subscription = form.watch((_value, { type }) => {
       if (type === "change") {
         setHasUnsavedChanges(true);
       }

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/page.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/page.tsx
@@ -111,7 +111,7 @@ export default async function AgentPage({ params }: Readonly<AgentPageProps>) {
               </Suspense>
               <div className="flex w-fit flex-col gap-6 p-6 md:p-0 md:pt-6">
                 <h1 className="text-start text-3xl font-semibold">
-                  {mdl.name}
+                  {metadata.title}
                 </h1>
                 <p className="text-card-foreground">
                   {metadata.short_description}

--- a/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/page.tsx
+++ b/apps/torus-allocator/src/app/(expanded-pages)/agent/[slug]/page.tsx
@@ -109,11 +109,11 @@ export default async function AgentPage({ params }: Readonly<AgentPageProps>) {
               >
                 <AgentIcon alt={`${mdl.name} icon`} icon={icon} />
               </Suspense>
-              <div className="flex w-fit flex-col gap-6 p-6 md:p-0 md:pt-6">
+              <div className="flex w-fit flex-col gap-6 p-6 md:p-0 md:pt-6 md:pr-6">
                 <h1 className="text-start text-3xl font-semibold">
                   {metadata.title}
                 </h1>
-                <p className="text-card-foreground">
+                <p className="text-card-foreground word-break-break-word">
                   {metadata.short_description}
                 </p>
               </div>

--- a/apps/torus-allocator/src/app/_components/agent-card/agent-card-content.tsx
+++ b/apps/torus-allocator/src/app/_components/agent-card/agent-card-content.tsx
@@ -30,7 +30,7 @@ export function AgentCardContent({
   return (
     <CardContent>
       <Separator className="mb-4" />
-      <p className="text-sm md:min-h-14 line-clamp-3 break-words">
+      <p className="text-sm md:min-h-16 line-clamp-3 break-words">
         {displayDescription}
       </p>
     </CardContent>

--- a/apps/torus-allocator/src/app/_components/agent-card/agent-card-content.tsx
+++ b/apps/torus-allocator/src/app/_components/agent-card/agent-card-content.tsx
@@ -30,7 +30,9 @@ export function AgentCardContent({
   return (
     <CardContent>
       <Separator className="mb-4" />
-      <p className="text-sm md:min-h-14 break-words">{displayDescription}</p>
+      <p className="text-sm md:min-h-14 line-clamp-3 break-words">
+        {displayDescription}
+      </p>
     </CardContent>
   );
 }

--- a/apps/torus-governance/src/app/_components/proposal/register-agent.tsx
+++ b/apps/torus-governance/src/app/_components/proposal/register-agent.tsx
@@ -584,7 +584,7 @@ export function RegisterAgent() {
               name="body"
               render={({ field }) => (
                 <FormItem className="flex flex-col">
-                  <FormLabel>Agent Description </FormLabel>
+                  <FormLabel>Agent Description</FormLabel>
                   <FormControl>
                     <Textarea
                       {...field}

--- a/apps/torus-governance/src/app/_components/proposal/register-agent.tsx
+++ b/apps/torus-governance/src/app/_components/proposal/register-agent.tsx
@@ -66,7 +66,10 @@ const registerAgentSchema = z.object({
       `Max ${AGENT_SHORT_DESCRIPTION_MAX_LENGTH} characters`,
     ),
   title: z.string().min(1, "Agent title is required"),
-  body: z.string().min(1, "Agent description is required"),
+  body: z
+    .string()
+    .min(1, "Agent description is required")
+    .max(50_000, "Agent description must be less than 50,000 characters"),
   twitter: z.string().optional(),
   github: z.string().optional(),
   telegram: z.string().optional(),
@@ -581,15 +584,20 @@ export function RegisterAgent() {
               name="body"
               render={({ field }) => (
                 <FormItem className="flex flex-col">
-                  <FormLabel>Agent Description</FormLabel>
+                  <FormLabel>Agent Description </FormLabel>
                   <FormControl>
                     <Textarea
                       {...field}
                       placeholder="Describe your agent (Markdown supported, HTML tags are not supported)"
                       rows={5}
+                      maxLength={50000}
                       required
                     />
                   </FormControl>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {new Intl.NumberFormat("en-US").format(field.value.length)}{" "}
+                    / 50,000 characters
+                  </p>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/torus-portal/src/app/(pages)/register-agent/_components/register-agent-form.tsx
+++ b/apps/torus-portal/src/app/(pages)/register-agent/_components/register-agent-form.tsx
@@ -643,9 +643,16 @@ export default function RegisterAgentForm() {
                           {...field}
                           placeholder="Describe your agent (Markdown supported, HTML tags are not supported)"
                           rows={5}
+                          maxLength={50000}
                           required
                         />
                       </FormControl>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {new Intl.NumberFormat("en-US").format(
+                          field.value.length,
+                        )}{" "}
+                        / 50,000 characters
+                      </p>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/apps/torus-portal/src/app/(pages)/register-agent/_components/register-agent-form.tsx
+++ b/apps/torus-portal/src/app/(pages)/register-agent/_components/register-agent-form.tsx
@@ -66,7 +66,10 @@ const registerAgentSchema = z.object({
       `Max ${AGENT_SHORT_DESCRIPTION_MAX_LENGTH} characters`,
     ),
   title: z.string().min(1, "Agent title is required"),
-  body: z.string().min(1, "Agent description is required"),
+  body: z
+    .string()
+    .min(1, "Agent description is required")
+    .max(50_000, "Agent description must be less than 50,000 characters"),
   twitter: z.string().optional(),
   github: z.string().optional(),
   telegram: z.string().optional(),

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -84,6 +84,9 @@ const config = {
             display: "none",
           },
         },
+        ".word-break-break-word": {
+          "word-break": "break-word",
+        },
       });
     }),
   ],


### PR DESCRIPTION
Updates the agent update form to handle image URLs directly, removing the need for a separate image file state. This simplifies the data flow and improves the image update process. It leverages a custom hook for fetching blob URLs from IPFS URIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image input for updating agents now supports file uploads with size and type validations.
  * Image previews display uploaded files or existing preview URLs using blob URLs.

* **Improvements**
  * Enhanced unsaved changes tracking with confirmation dialogs on close.
  * "Save Changes" button shows a loading indicator and disables actions during saving.
  * Dialog prevents closing during active uploads.
  * Centralized image preview management via blob URLs for consistency.
  * Improved image upload process with automatic conversion and pinning of blob URLs.
  * Agent page heading now shows the title from metadata for accurate naming.
  * Description text in agent cards is visually truncated to three lines for cleaner display.
  * Added word-break styling to improve text wrapping in descriptions.
  * Increased maximum allowed length for agent descriptions to 50,000 characters.
  * Character count displays added for agent description inputs in registration and proposal forms.

* **Bug Fixes**
  * More reliable image preview and upload behavior when editing agent details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->