### PR TITLE
FIX: Change from grantor to grantee, TOR to TORUS, the Torus Network to Torus and Grant to Delegate

### DIFF
--- a/apps/torus-governance/src/app/_components/vote-data.tsx
+++ b/apps/torus-governance/src/app/_components/vote-data.tsx
@@ -1,5 +1,7 @@
 import type { ProposalStatus } from "@torus-network/sdk";
+
 import { Card, CardHeader } from "@torus-ts/ui/components/card";
+
 import {
   calcProposalFavorablePercent,
   handleProposalVotesAgainst,
@@ -40,7 +42,7 @@ export const VoteData = (props: VoteDataProps) => {
         <div className="flex items-center gap-2 divide-x">
           <span className="text-xs">
             {handleProposalVotesInFavor(proposalStatus)}
-            <span className="text-muted-foreground"> TOR</span>
+            <span className="text-muted-foreground"> TORUS</span>
           </span>
           <span className="text-muted-foreground pl-2 text-sm font-semibold">
             {favorablePercent.toFixed(2)}%
@@ -60,7 +62,7 @@ export const VoteData = (props: VoteDataProps) => {
         <div className="flex items-center gap-2 divide-x">
           <span className="text-xs">
             {handleProposalVotesAgainst(proposalStatus)}
-            <span className="text-muted-foreground"> TOR</span>
+            <span className="text-muted-foreground"> TORUS</span>
           </span>
           <span className="text-muted-foreground pl-2 text-sm font-semibold">
             {againstPercent.toFixed(2)}%

--- a/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/graph-sheet/graph-sheet-details/graph-sheet-details-card.tsx
+++ b/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/graph-sheet/graph-sheet-details/graph-sheet-details-card.tsx
@@ -123,7 +123,7 @@ export function NodeDetailsCard({
                   <div className="flex flex-col gap-1 w-full pr-2">
                     <div className="flex items-center justify-between">
                       <span className="font-medium text-white">
-                        {isOutgoing ? "← Granted " : "→ Received "}
+                        {isOutgoing ? "← Delegated " : "→ Received "}
                         Permission{" "}
                         {smallAddress(
                           String(details?.permissions.permissionId),

--- a/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/graph-sheet/graph-sheet-details/graph-sheet-details-permission.tsx
+++ b/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/graph-sheet/graph-sheet-details/graph-sheet-details-permission.tsx
@@ -185,7 +185,7 @@ export function GraphSheetDetailsPermission({
                 {smallAddress(permissionData.grantorAccountId)}
               </p>
               <p className="text-xs text-muted-foreground">
-                Account that granted this permission
+                Account that delegated this permission
               </p>
             </div>
           </div>

--- a/apps/torus-portal/src/app/(pages)/create-permission/(namespace)/_components/grant-namespace-permission-form-content.tsx
+++ b/apps/torus-portal/src/app/(pages)/create-permission/(namespace)/_components/grant-namespace-permission-form-content.tsx
@@ -44,6 +44,11 @@ import type {
 // In the future we are going to have all the other names from namespace to Capability Permission
 // TODO : Change all namespace to Capability Permission
 
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 interface GrantNamespacePermissionFormProps {
   form: GrantNamespacePermissionForm;
   mutation: GrantNamespacePermissionMutation;
@@ -100,13 +105,13 @@ export function GrantNamespacePermissionFormComponent({
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <WalletConnectionWarning isAccountConnected={isAccountConnected} />
 
-            {/* Grantee */}
+            {/* Recipient */}
             <FormField
               control={form.control}
               name="grantee"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Grantee</FormLabel>
+                  <FormLabel>Recipient</FormLabel>
                   <FormControl>
                     <Input
                       {...field}

--- a/apps/torus-portal/src/app/(pages)/create-permission/(namespace)/_components/grant-namespace-permission-form-content.tsx
+++ b/apps/torus-portal/src/app/(pages)/create-permission/(namespace)/_components/grant-namespace-permission-form-content.tsx
@@ -94,9 +94,9 @@ export function GrantNamespacePermissionFormComponent({
   return (
     <Card className="border-none w-full">
       <CardHeader>
-        <CardTitle>Grant Capability Permission</CardTitle>
+        <CardTitle>Delegate Capability Permission</CardTitle>
         <CardDescription>
-          Grant permission to access a specific capability permission path.
+          Delegate permission to access a specific capability permission path.
         </CardDescription>
       </CardHeader>
 
@@ -422,14 +422,14 @@ export function GrantNamespacePermissionFormComponent({
               {mutation.isPending ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Granting Permission...
+                  Awaiting Signature...
                 </>
               ) : !isAccountConnected ? (
                 "Connect Wallet to Continue"
               ) : namespaceOptions.length === 0 ? (
                 "Create a Capability Permission First"
               ) : (
-                "Grant Capability Permission"
+                "Delegate Capability Permission"
               )}
             </Button>
           </form>

--- a/apps/torus-portal/src/app/(pages)/create-permission/(namespace)/_components/grant-namespace-permission-form.tsx
+++ b/apps/torus-portal/src/app/(pages)/create-permission/(namespace)/_components/grant-namespace-permission-form.tsx
@@ -15,6 +15,11 @@ import { transformFormDataToSDK } from "./grant-namespace-permission-form-utils"
 // In the future we are going to have all the other names from namespace to Capability Permission
 // TODO : Change all namespace to Capability Permission
 
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 interface GrantNamespacePermissionFormProps {
   onSuccess?: () => void;
 }

--- a/apps/torus-portal/src/app/(pages)/create-permission/emission/_components/grant-emission-permission-form-content.tsx
+++ b/apps/torus-portal/src/app/(pages)/create-permission/emission/_components/grant-emission-permission-form-content.tsx
@@ -1,3 +1,8 @@
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 "use client";
 
 import { useCallback, useEffect } from "react";
@@ -34,7 +39,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@torus-ts/ui/components/select";
-import { WalletConnectionWarning } from "@torus-ts/ui/components/wallet-connection-warning";
+import {
+  WalletConnectionWarning,
+} from "@torus-ts/ui/components/wallet-connection-warning";
 
 import { useAvailableStreams } from "~/hooks/use-available-streams";
 
@@ -629,7 +636,7 @@ export function GrantEmissionPermissionFormComponent({
                       <SelectContent>
                         <SelectItem value="Irrevocable">Irrevocable</SelectItem>
                         <SelectItem value="RevocableByGrantor">
-                          Revocable by Grantor
+                          Revocable by Delegator
                         </SelectItem>
                         <SelectItem value="RevocableByArbiters">
                           Revocable by Arbiters

--- a/apps/torus-portal/src/app/(pages)/create-permission/emission/_components/grant-emission-permission-form-content.tsx
+++ b/apps/torus-portal/src/app/(pages)/create-permission/emission/_components/grant-emission-permission-form-content.tsx
@@ -192,7 +192,7 @@ export function GrantEmissionPermissionFormComponent({
     <div className="pb-12 w-full mx-auto flex items-end justify-end">
       <Card className="border-0">
         <CardHeader>
-          <CardTitle>Grant Emission Permission</CardTitle>
+          <CardTitle>Delegate Emission Permission</CardTitle>
           <CardDescription>
             Create and configure a new emission permission, to delegate it to a
             set of agents{" "}
@@ -766,7 +766,7 @@ export function GrantEmissionPermissionFormComponent({
                     !form.formState.isValid
                   }
                 >
-                  {mutation.isPending ? "Creating..." : "Create Permission"}
+                  {mutation.isPending ? "Awaiting Signature..." : "Delegate Permission"}
                 </Button>
               </div>
             </CardContent>

--- a/apps/torus-portal/src/app/(pages)/create-permission/emission/_components/permission-success-dialog.tsx
+++ b/apps/torus-portal/src/app/(pages)/create-permission/emission/_components/permission-success-dialog.tsx
@@ -26,8 +26,8 @@ export function PermissionSuccessDialog({
 
         <div className="py-4">
           <p className="mb-4">
-            Your emission permission has been granted successfully.
-            {/* Your emission permission has been granted successfully. Now you can
+            Your emission permission has been delegated successfully.
+            {/* Your emission permission has been delegated successfully. Now you can
             create constraints to define specific rules and conditions for this
             permission. */}
           </p>

--- a/apps/torus-portal/src/app/(pages)/edit-permission/_components/edit-emission-permission-form-content.tsx
+++ b/apps/torus-portal/src/app/(pages)/edit-permission/_components/edit-emission-permission-form-content.tsx
@@ -1,11 +1,21 @@
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 "use client";
 
 import { useCallback } from "react";
+
+import { AlertCircle, Loader2, Lock, Plus, Trash2, Wand2 } from "lucide-react";
+import { useFieldArray } from "react-hook-form";
+
 import type { SS58Address } from "@torus-network/sdk";
 import { checkSS58 } from "@torus-network/sdk";
-import { Loader2, Plus, Trash2, Wand2, Lock, AlertCircle } from "lucide-react";
-import { useFieldArray } from "react-hook-form";
+
 import { useTorus } from "@torus-ts/torus-provider";
+import { Alert, AlertDescription } from "@torus-ts/ui/components/alert";
+import { Badge } from "@torus-ts/ui/components/badge";
 import { Button } from "@torus-ts/ui/components/button";
 import { Card, CardContent } from "@torus-ts/ui/components/card";
 import {
@@ -24,10 +34,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@torus-ts/ui/components/select";
-import { Badge } from "@torus-ts/ui/components/badge";
-import { Alert, AlertDescription } from "@torus-ts/ui/components/alert";
 import { WalletConnectionWarning } from "@torus-ts/ui/components/wallet-connection-warning";
+
 import { useAvailableStreams } from "~/hooks/use-available-streams";
+
 import type {
   EditEmissionPermissionForm,
   EditEmissionPermissionFormData,
@@ -117,30 +127,32 @@ export function EditEmissionPermissionFormComponent({
         <div className="flex items-center gap-2 mb-2">
           <Badge
             variant={
-              permissionInfo.userRole === "grantor" ? "default" : "secondary"
+              permissionInfo.userRole === "delegator" ? "default" : "secondary"
             }
           >
-            {permissionInfo.userRole === "grantor" ? "Grantor" : "Grantee"}
+            {permissionInfo.userRole === "delegator"
+              ? "Delegator"
+              : "Recipient"}
           </Badge>
           <span className="text-sm">
             Permission: {permissionInfo.permissionId.substring(0, 16)}...
           </span>
         </div>
-        {permissionInfo.userRole === "grantor" ? (
+        {permissionInfo.userRole === "delegator" ? (
           canEditStreams && canEditDistribution ? (
             <p className="text-sm">
-              As grantor, you can edit all fields based on the permission's
+              As delegator, you can edit all fields based on the permission's
               revocation terms.
             </p>
           ) : (
             <p className="text-sm">
-              As grantor, your edit permissions are limited by the revocation
+              As delegator, your edit permissions are limited by the revocation
               terms. You can only edit targets.
             </p>
           )
         ) : (
           <p className="text-sm">
-            As grantee, you can only edit target accounts and their weights.
+            As recipient, you can only edit target accounts and their weights.
             Stream and distribution changes are not permitted.
           </p>
         )}

--- a/apps/torus-portal/src/app/(pages)/edit-permission/_components/edit-emission-permission-form-schema.ts
+++ b/apps/torus-portal/src/app/(pages)/edit-permission/_components/edit-emission-permission-form-schema.ts
@@ -1,6 +1,8 @@
-import { z } from "zod";
 import type { UseFormReturn } from "react-hook-form";
+import { z } from "zod";
+
 import { SS58_SCHEMA } from "@torus-network/sdk";
+
 import {
   createStreamPercentageValidator,
   createTargetWeightValidator,
@@ -116,9 +118,9 @@ export type EditEmissionPermissionForm =
 // Permission info for display
 export interface PermissionInfo {
   permissionId: string;
-  grantor: string;
-  grantee: string;
-  userRole: "grantor" | "grantee";
+  delegator: string;
+  recipient: string;
+  userRole: "delegator" | "recipient";  
   canEditStreams: boolean;
   canEditDistribution: boolean;
   currentTargets: { account: string; weight: string }[];

--- a/apps/torus-portal/src/app/(pages)/edit-permission/_components/edit-emission-permission-form.tsx
+++ b/apps/torus-portal/src/app/(pages)/edit-permission/_components/edit-emission-permission-form.tsx
@@ -37,6 +37,11 @@ import { PermissionSelector } from "~/app/_components/permission-selector";
 // In the future we are going to have all the other names from namespace to Capability Permission
 // TODO : Change all namespace to Capability Permission
 
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import {
   PermissionWithDetails,

--- a/apps/torus-portal/src/app/(pages)/edit-permission/_components/revoke-permission-button.tsx
+++ b/apps/torus-portal/src/app/(pages)/edit-permission/_components/revoke-permission-button.tsx
@@ -1,3 +1,8 @@
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 "use client";
 
 import { useState } from "react";
@@ -98,10 +103,10 @@ export function RevokePermissionButton({
     // Use new database structure if available
     if (permissionData) {
       const perm = permissionData.permissions;
-      const isGrantor = perm.grantorAccountId === userAddress;
+      const isDelegator = perm.grantorAccountId === userAddress;
 
-      // Only grantors can revoke permissions, and only if revocation terms allow it
-      if (!isGrantor) return false;
+      // Only delegators can revoke permissions, and only if revocation terms allow it
+      if (!isDelegator) return false;
 
       switch (perm.revocationType) {
         case "revocable_by_grantor":
@@ -122,10 +127,10 @@ export function RevokePermissionButton({
 
     // Legacy support for PermissionContract
     if (permission) {
-      const isGrantor = permission.grantor === userAddress;
+      const isDelegator = permission.grantor === userAddress;
 
-      // Only grantors can revoke permissions, and only if revocation terms allow it
-      if (!isGrantor) return false;
+      // Only delegators can revoke permissions, and only if revocation terms allow it
+      if (!isDelegator) return false;
 
       return match(permission.revocation)({
         RevocableByGrantor() {
@@ -193,8 +198,8 @@ export function RevokePermissionButton({
     // Use new database structure if available
     if (permissionData) {
       const perm = permissionData.permissions;
-      const isGrantor = perm.grantorAccountId === userAddress;
-      if (!isGrantor) return "Only the grantor can revoke permissions";
+      const isDelegator = perm.grantorAccountId === userAddress;
+      if (!isDelegator) return "Only the delegator can revoke permissions";
 
       switch (perm.revocationType) {
         case "revocable_by_grantor":
@@ -218,8 +223,8 @@ export function RevokePermissionButton({
 
     // Legacy support for PermissionContract
     if (permission) {
-      const isGrantor = permission.grantor === userAddress;
-      if (!isGrantor) return "Only the grantor can revoke permissions";
+      const isDelegator = permission.grantor === userAddress;
+      if (!isDelegator) return "Only the delegator can revoke permissions";
 
       return match(permission.revocation)({
         RevocableByGrantor() {
@@ -281,12 +286,12 @@ export function RevokePermissionButton({
                   <br />
                   Type: {getPermissionType()}
                   <br />
-                  Grantor:{" "}
+                  Delegator:{" "}
                   {permissionData
                     ? permissionData.permissions.grantorAccountId
                     : permission?.grantor}
                   <br />
-                  Grantee:{" "}
+                  Recipient:{" "}
                   {permissionData
                     ? permissionData.permissions.granteeAccountId
                     : permission?.grantee}

--- a/apps/torus-portal/src/app/(pages)/edit-permission/page.tsx
+++ b/apps/torus-portal/src/app/(pages)/edit-permission/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
+
 import PortalFormContainer from "~/app/_components/portal-form-container";
+
 import EditEmissionPermissionForm from "./_components/edit-emission-permission-form";
 
 export const metadata: Metadata = {
   title: "Edit/Revoke Permission | Torus Portal",
-  description: "Edit existing permissions on the Torus Network",
+  description: "Edit existing permissions on Torus",
 };
 
 export default function EditPermissionPage() {

--- a/apps/torus-portal/src/app/(pages)/register-capability/_components/namespace-success-dialog.tsx
+++ b/apps/torus-portal/src/app/(pages)/register-capability/_components/namespace-success-dialog.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { CheckCircle } from "lucide-react";
+
+import { Button } from "@torus-ts/ui/components/button";
 import {
   Dialog,
   DialogContent,
@@ -7,8 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@torus-ts/ui/components/dialog";
-import { Button } from "@torus-ts/ui/components/button";
-import { CheckCircle } from "lucide-react";
 
 // Every single namespace name has been changed to Capability Permission
 // as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
@@ -45,9 +46,8 @@ export function NamespaceSuccessDialog({
             Capability Permission Created Successfully!
           </DialogTitle>
           <DialogDescription className="text-center">
-            Your capability permission has been created on the Torus Network.
-            Agents can now use this capability permission to handle API
-            requests.
+            Your capability permission has been created on Torus. Agents can now
+            use this capability permission to handle API requests.
           </DialogDescription>
         </DialogHeader>
         <div className="flex justify-center mt-6">

--- a/apps/torus-portal/src/app/_components/permission-selector.tsx
+++ b/apps/torus-portal/src/app/_components/permission-selector.tsx
@@ -1,7 +1,32 @@
+// Every single grantor/grantee terminology has been changed to delegator/recipient
+// as requested here: https://coda.io/d/RENLABS-CORE-DEVELOPMENT-DOCUMENTS_d5Vgr5OavNK/Text-change-requests_su4jQAlx
+// This change affects UI labels, variable names, and function names throughout the codebase
+// TODO : Ensure all grantor/grantee references are updated to delegator/recipient
+
 "use client";
 
 import { useEffect } from "react";
+
+import { Copy } from "lucide-react";
+import type { Control } from "react-hook-form";
+
+import { smallAddress } from "@torus-network/torus-utils/subspace";
+
+import { useTorus } from "@torus-ts/torus-provider";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@torus-ts/ui/components/card";
 import { CopyButton } from "@torus-ts/ui/components/copy-button";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@torus-ts/ui/components/form";
 import {
   Select,
   SelectContent,
@@ -11,24 +36,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@torus-ts/ui/components/select";
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@torus-ts/ui/components/form";
-import { useTorus } from "@torus-ts/torus-provider";
-import { Copy } from "lucide-react";
-import type { Control } from "react-hook-form";
-import { smallAddress } from "@torus-network/torus-utils/subspace";
+
 import { api as trpcApi } from "~/trpc/react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@torus-ts/ui/components/card";
+
 import type { PermissionWithDetails } from "../(pages)/edit-permission/_components/revoke-permission-button";
 
 interface PermissionSelectorProps {
@@ -64,25 +74,25 @@ export function PermissionSelector(props: PermissionSelectorProps) {
     return "Unknown";
   };
 
-  // Prioritize grantor permissions for auto-selection
+  // Prioritize delegator permissions for auto-selection
   const getDefaultPermissionId = () => {
     if (!userPermissions?.length) return null;
 
-    // First try to find a grantor permission
-    const grantorPermission = userPermissions.find(
+    // First try to find a delegator permission
+    const delegatorPermission = userPermissions.find(
       (item) => item.permissions.grantorAccountId === selectedAccount?.address,
     );
 
-    if (grantorPermission) {
-      return grantorPermission.permissions.permissionId;
+    if (delegatorPermission) {
+      return delegatorPermission.permissions.permissionId;
     }
 
-    // Fall back to first grantee permission
-    const granteePermission = userPermissions.find(
+    // Fall back to first recipient permission
+    const recipientPermission = userPermissions.find(
       (item) => item.permissions.granteeAccountId === selectedAccount?.address,
     );
 
-    return granteePermission?.permissions.permissionId ?? null;
+    return recipientPermission?.permissions.permissionId ?? null;
   };
 
   const defaultPermissionId = getDefaultPermissionId();
@@ -159,11 +169,11 @@ export function PermissionSelector(props: PermissionSelectorProps) {
         value: permissionType,
       },
       {
-        label: "Grantor",
+        label: "Delegator",
         value: smallAddress(permission.grantorAccountId),
       },
       {
-        label: "Grantee",
+        label: "Recipient",
         value: smallAddress(permission.granteeAccountId),
       },
       {
@@ -175,9 +185,12 @@ export function PermissionSelector(props: PermissionSelectorProps) {
       },
       {
         label: "Revocation",
+        // Transform revocation type and update grantor/grantee terminology to delegator/recipient
         value: permission.revocationType
           .replace(/_/g, " ")
-          .replace(/\b\w/g, (l) => l.toUpperCase()),
+          .replace(/\b\w/g, (l) => l.toUpperCase())
+          .replace("Grantor", "Delegator")
+          .replace("Grantee", "Recipient"),
       },
       {
         label: "Created At",
@@ -224,14 +237,14 @@ export function PermissionSelector(props: PermissionSelectorProps) {
                     if (!userPermissions) return null;
 
                     // Separate permissions by role and deduplicate
-                    const grantorPermissions = userPermissions.filter(
+                    const delegatorPermissions = userPermissions.filter(
                       (item) =>
                         item.permissions.grantorAccountId ===
                         selectedAccount?.address,
                     );
 
-                    // Filter out permissions where user is also grantor to avoid duplicates
-                    const granteeOnlyPermissions = userPermissions.filter(
+                    // Filter out permissions where user is also delegator to avoid duplicates
+                    const recipientOnlyPermissions = userPermissions.filter(
                       (item) =>
                         item.permissions.granteeAccountId ===
                           selectedAccount?.address &&
@@ -241,10 +254,10 @@ export function PermissionSelector(props: PermissionSelectorProps) {
 
                     return (
                       <>
-                        {granteeOnlyPermissions.length > 0 && (
+                        {recipientOnlyPermissions.length > 0 && (
                           <SelectGroup>
-                            <SelectLabel>As Grantee</SelectLabel>
-                            {granteeOnlyPermissions.map((item) => {
+                            <SelectLabel>As Recipient</SelectLabel>
+                            {recipientOnlyPermissions.map((item) => {
                               const permissionId =
                                 item.permissions.permissionId;
                               const permissionType = getPermissionType(item);
@@ -264,10 +277,10 @@ export function PermissionSelector(props: PermissionSelectorProps) {
                             })}
                           </SelectGroup>
                         )}
-                        {grantorPermissions.length > 0 && (
+                        {delegatorPermissions.length > 0 && (
                           <SelectGroup>
-                            <SelectLabel>As Grantor</SelectLabel>
-                            {grantorPermissions.map((item) => {
+                            <SelectLabel>As Delegator</SelectLabel>
+                            {delegatorPermissions.map((item) => {
                               const permissionId =
                                 item.permissions.permissionId;
                               const permissionType = getPermissionType(item);

--- a/apps/torus-wallet/src/app/(transfers)/_components/faucet/faucet-form.tsx
+++ b/apps/torus-wallet/src/app/(transfers)/_components/faucet/faucet-form.tsx
@@ -85,7 +85,7 @@ export function FaucetForm({
                   <LoaderCircle className="animate-spin" /> {loadMessage}{" "}
                 </>
               ) : (
-                <>Submit Faucet Request (50 TOR)</>
+                <>Submit Faucet Request (50 TORUS)</>
               )}
             </Button>
             <DropdownMenu>
@@ -101,13 +101,13 @@ export function FaucetForm({
 
               <DropdownMenuContent align="end" style={{ width }}>
                 <DropdownMenuItem onClick={async () => await onSubmit(2)}>
-                  Submit 2x Faucet Requests (100 TOR)
+                  Submit 2x Faucet Requests (100 TORUS)
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={async () => await onSubmit(10)}>
-                  Submit 10x Faucet Requests (500 TOR)
+                  Submit 10x Faucet Requests (500 TORUS)
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={async () => await onSubmit(20)}>
-                  Submit 20x Faucet Requests (1000 TOR)
+                  Submit 20x Faucet Requests (1000 TORUS)
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/apps/torus-wallet/src/app/(transfers)/_components/faucet/faucet.tsx
+++ b/apps/torus-wallet/src/app/(transfers)/_components/faucet/faucet.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { ApiPromise } from "@polkadot/api";
-import { tryAsync } from "@torus-network/torus-utils/try-catch";
 import { useForm } from "react-hook-form";
+
+import { tryAsync } from "@torus-network/torus-utils/try-catch";
 
 import { useTorus } from "@torus-ts/torus-provider";
 import { useToast } from "@torus-ts/ui/hooks/use-toast";
@@ -67,7 +68,7 @@ export function Faucet() {
           workResult,
           recipient,
         );
-        toast.success("+50 TOR added to your account.");
+        toast.success("+50 TORUS added to your account.");
         await accountFreeBalance.refetch();
       } catch (err) {
         if (err instanceof Error) {

--- a/apps/torus-wallet/src/app/_components/currency-swap.tsx
+++ b/apps/torus-wallet/src/app/_components/currency-swap.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
+
+import { ArrowLeftRight } from "lucide-react";
+
+import { fromNano, toNano } from "@torus-network/torus-utils/subspace";
+
 import { Button } from "@torus-ts/ui/components/button";
 import { Input } from "@torus-ts/ui/components/input";
-import { ArrowLeftRight } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+
 import { convertTORUSToUSD, convertUSDToTorus } from "~/utils/helpers";
+
 import { AmountButtons } from "./amount-buttons";
-import { fromNano, toNano } from "@torus-network/torus-utils/subspace";
 
 interface CurrencySwapProps {
   amount: string;
@@ -86,7 +91,7 @@ export function CurrencySwap({
             placeholder={`Amount of ${inputType}`}
             disabled={disabled}
             type="number"
-            label={inputType === "TORUS" ? "TOR" : "USD"}
+            label={inputType === "TORUS" ? "TORUS" : "USD"}
             min={fromNano(minAllowedStakeData)}
           />
         </div>
@@ -104,9 +109,9 @@ export function CurrencySwap({
         <div className="flex flex-col w-full sm:w-1/2">
           <Input
             value={displayAmount}
-            placeholder={`Amount of ${inputType === "TORUS" ? "USD" : "TOR"}`}
+            placeholder={`Amount of ${inputType === "TORUS" ? "USD" : "TORUS"}`}
             disabled={true}
-            label={inputType === "TORUS" ? "USD" : "TOR"}
+            label={inputType === "TORUS" ? "USD" : "TORUS"}
           />
         </div>
       </div>

--- a/apps/torus-wallet/src/app/_components/wallet-balance.tsx
+++ b/apps/torus-wallet/src/app/_components/wallet-balance.tsx
@@ -1,13 +1,18 @@
 "use client";
 
+import { Suspense, useMemo } from "react";
+
+import { Copy, Lock, Scale, Unlock } from "lucide-react";
+import Image from "next/image";
+
 import { formatToken, smallAddress } from "@torus-network/torus-utils/subspace";
+
 import { Card } from "@torus-ts/ui/components/card";
 import { CopyButton } from "@torus-ts/ui/components/copy-button";
 import { Skeleton } from "@torus-ts/ui/components/skeleton";
+
 import { useWallet } from "~/context/wallet-provider";
-import { Copy, Lock, Scale, Unlock } from "lucide-react";
-import Image from "next/image";
-import { Suspense, useMemo } from "react";
+
 import { TorusAnimation } from "./torus-animation";
 
 const BALANCE_ICONS = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all instances of "grantor/grantee" to "delegator/recipient" and "grant/granted" to "delegate/delegated" across permission-related UI labels, button texts, and descriptions for consistency.
  * Changed token abbreviation in wallet and governance app interfaces from "TOR" to "TORUS" for improved clarity.
  * Minor updates to page and dialog descriptions, removing "Network" from "Torus Network" where applicable.
  * Adjusted and clarified import order in several files for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->