### PR TITLE
Docker cache

### DIFF
--- a/.github/workflows/app-deployment-template.yml
+++ b/.github/workflows/app-deployment-template.yml
@@ -57,6 +57,8 @@ jobs:
           context: .
           push: true
           file: docker/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             APP_NAME=${{ inputs.app_name }}
             TURBO_API=${{ vars.TURBO_API }}

--- a/.github/workflows/dry-run-build-template.yml
+++ b/.github/workflows/dry-run-build-template.yml
@@ -60,6 +60,8 @@ jobs:
           context: .
           push: false
           file: docker/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             APP_NAME=${{ inputs.app_name }}
             TURBO_API=${{ vars.TURBO_API }}

--- a/.github/workflows/pr-preview-template.yml
+++ b/.github/workflows/pr-preview-template.yml
@@ -58,6 +58,8 @@ jobs:
           context: .
           push: true
           file: docker/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             APP_NAME=${{ inputs.app_name }}
             TURBO_API=${{ vars.TURBO_API }}


### PR DESCRIPTION
This add the ability to cache docker layers on the Github Caching system, this WILL NOT impact too much the build times, as most apps are already using the turbo cache. The most impacted will be the bridge since it takes a lot of time to do python crap