### PR TITLE
fix: enable old RPC node workaround with connection hook

### DIFF
--- a/packages/torus-sdk-ts/src/chain/torus0/namespace.ts
+++ b/packages/torus-sdk-ts/src/chain/torus0/namespace.ts
@@ -100,24 +100,6 @@ export async function queryNamespaceEntriesOf(
 
 // ---- Namespace Path Creation Cost ----
 
-const NS_CREATION_COST_RPC_URL = "wss://api-30.nodes.torus.network";
-
-/**
- * GAMBIARRA: connect to hardcoded node with image that exposes RPC method
- * to compute namespace path creation cost.
- *
- * This should be dropped once the main API nodes are updated.
- */
-async function connectToNsCreationCostNode() {
-  const provider = new WsProvider(NS_CREATION_COST_RPC_URL);
-  const [error, api] = await tryAsync(ApiPromise.create({ provider }));
-  if (error !== undefined) {
-    console.error("Error creating API:", error);
-    throw error;
-  }
-  return api;
-}
-
 /**
  * Queries the cost of creating a namespace path.
  *
@@ -158,9 +140,6 @@ export async function queryNamespacePathCreationCost(
   if (pathError !== undefined) {
     return makeErr(new Error(`Invalid namespace path: ${pathError.message}`));
   }
-
-  // // GAMBIARRA: connect to hardcoded node with image that exposes RPC method
-  // const api = await connectToNsCreationCostNode();
 
   // Call the RPC method manually since it's not auto-generated
   // Note: Using provider send method because this RPC method is not auto-decorated

--- a/packages/torus-sdk-ts/src/utils/index.ts
+++ b/packages/torus-sdk-ts/src/utils/index.ts
@@ -8,6 +8,8 @@ import { ApiPromise, WsProvider } from "@polkadot/api";
 export async function connectToChainRpc(
   wsEndpoint: string,
 ): Promise<ApiPromise> {
+  console.debug("Connecting to chain RPC endpoint:", wsEndpoint);
+
   const wsProvider = new WsProvider(wsEndpoint);
   const api = await ApiPromise.create({ provider: wsProvider });
 


### PR DESCRIPTION
## Summary

- Re-enable the temporary connection to api-30.nodes.torus.network for namespace path creation cost RPC method
- Add `useOldImageNodeApi()` hook to manage connection lifecycle and prevent reconnecting on each render
- Clean up unused code in torus-sdk-ts namespace module

## Context

This workaround is needed until the main API nodes are updated with the required RPC methods for computing namespace path creation costs.

The hook ensures we maintain a single API connection instance throughout the component lifecycle, avoiding unnecessary reconnections on each render.

## Related Issues

- Linear: [CHAIN-116](https://linear.app/renlabs-dev/issue/CHAIN-116/check-whats-going-on-with-fp-pallets)
- Discord discussion: https://discord.com/channels/1306654856286699590/1395038210794586183

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic connection to a dedicated WebSocket node for namespace path creation cost and agent registration burn calculations, ensuring accurate queries for these features.

* **Bug Fixes**
  * Improved reliability of namespace path creation cost queries by always using the correct node connection.

* **Chores**
  * Added debug logging for WebSocket endpoint connections.
  * Cleaned up unused code related to old connection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->