### PR TITLE
feat: add emission calc with weekly torus on portal (WEB-264)

### DIFF
--- a/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/force-graph/force-graph-canvas.tsx
+++ b/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/force-graph/force-graph-canvas.tsx
@@ -118,7 +118,7 @@ export function ForceGraphCanvas({
       <Canvas
         camera={{ position: [0, 0, 600], far: 8000 }}
         shadows
-        performance={{ min: 0.5 }}
+        performance={{ min: 0.2, max: 0.4 }}
       >
         <Suspense fallback={null}>
           <ForceGraphScene

--- a/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/force-graph/force-graph-constants.ts
+++ b/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/force-graph/force-graph-constants.ts
@@ -23,14 +23,14 @@ export const graphConstants = {
       allocator: {
         type: "sphere",
         radius: 28,
-        widthSegments: 36,
-        heightSegments: 36,
+        widthSegments: 24,
+        heightSegments: 24,
       },
       rootNode: {
         type: "sphere",
         radius: 15,
-        widthSegments: 24,
-        heightSegments: 24,
+        widthSegments: 16,
+        heightSegments: 16,
       },
       permissionNode: {
         type: "icosahedron",
@@ -40,14 +40,14 @@ export const graphConstants = {
       targetNode: {
         type: "sphere",
         radius: 13,
-        widthSegments: 24,
-        heightSegments: 24,
+        widthSegments: 16,
+        heightSegments: 16,
       },
       userNode: {
         type: "sphere",
         radius: 13,
-        widthSegments: 24,
-        heightSegments: 24,
+        widthSegments: 16,
+        heightSegments: 16,
       },
       signalNode: {
         type: "tetrahedron",

--- a/apps/torus-portal/src/utils/calculate-emission-value.ts
+++ b/apps/torus-portal/src/utils/calculate-emission-value.ts
@@ -21,9 +21,10 @@ export function calculateEmissionValue(
   if (percentage === 0) return "0.00 TORUS/week";
 
   const percentageFactor = percentage / 100;
-  const incomingEmissions = accountEmissions.streams.incoming.tokensPerWeek.plus(
-    accountEmissions.root.tokensPerWeek,
-  );
+  const incomingEmissions =
+    accountEmissions.streams.incoming.tokensPerWeek.plus(
+      accountEmissions.root.tokensPerWeek,
+    );
 
   const calculatedValue = incomingEmissions.multipliedBy(
     makeTorAmount(percentageFactor),

--- a/apps/torus-portal/src/utils/calculate-emission-value.ts
+++ b/apps/torus-portal/src/utils/calculate-emission-value.ts
@@ -1,0 +1,35 @@
+import { makeTorAmount } from "@torus-network/torus-utils/torus/token";
+
+import type { AccountEmissionData } from "~/hooks/use-multiple-account-emissions";
+
+export function calculateEmissionValue(
+  percentage: number,
+  accountEmissions: AccountEmissionData | null | undefined,
+  isAccountConnected: boolean,
+  selectedAccountAddress: string | undefined,
+): string {
+  if (
+    !isAccountConnected ||
+    !selectedAccountAddress ||
+    !accountEmissions ||
+    accountEmissions.isLoading ||
+    accountEmissions.isError
+  ) {
+    return "calculating...";
+  }
+
+  if (percentage === 0) return "0.00 TORUS/week";
+
+  const percentageFactor = percentage / 100;
+  const incomingEmissions = accountEmissions.streams.incoming.tokensPerWeek.plus(
+    accountEmissions.root.tokensPerWeek,
+  );
+
+  const calculatedValue = incomingEmissions.multipliedBy(
+    makeTorAmount(percentageFactor),
+  );
+  const value = calculatedValue.toNumber();
+
+  if (value < 0.01 && value > 0) return "< 0.01 TORUS/week";
+  return `${value.toFixed(2)} TORUS/week`;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Show estimated TORUS/week emission values across Permission Details, Signal List, Create Signal slider, and permission creation flows; emissions are fetched per account and displayed per-stream and as totals.
  - Slider now propagates changes via an onChange handler.

- Performance
  - Tuned graph canvas throttling and reduced node geometry complexity for smoother interactions.

- Style
  - Reflowed permission and signal layouts, updated stream/weight badges, address truncation, and action placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->