### PR TITLE
feat: chain spec 24 web breaking changes (WEB-342)

### DIFF
--- a/apps/torus-portal/next-env.d.ts
+++ b/apps/torus-portal/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/torus-portal/next-env.d.ts
+++ b/apps/torus-portal/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited

--- a/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/graph-sheet/graph-sheet-details/graph-sheet-details-card.tsx
+++ b/apps/torus-portal/src/app/(pages)/(permission-graph)/_components/graph-sheet/graph-sheet-details/graph-sheet-details-card.tsx
@@ -1,10 +1,4 @@
-import { useMemo } from "react";
-
-import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
-import { useRouter } from "next/navigation";
-
 import { smallAddress } from "@torus-network/torus-utils/torus/address";
-
 import {
   Accordion,
   AccordionContent,
@@ -20,9 +14,10 @@ import {
   TabsList,
   TabsTrigger,
 } from "@torus-ts/ui/components/tabs";
-
 import { ShortenedCapabilityPath } from "~/utils/capability-path";
-
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import type {
   allPermissions,
   CustomGraphData,
@@ -143,10 +138,10 @@ export function NodeDetailsCard({
     icon: React.ReactNode,
   ) => (
     <div className="mb-6">
-      <div className="flex items-center gap-2 mb-3 px-2">
+      <div className="mb-3 flex items-center gap-2 px-2">
         {icon}
         <h3 className="font-semibold text-white">{title}</h3>
-        <span className="text-sm text-muted-foreground">
+        <span className="text-muted-foreground text-sm">
           ({permissions.length})
         </span>
       </div>
@@ -155,7 +150,7 @@ export function NodeDetailsCard({
           {/* Capabilities section */}
           {permissions.some((p) => p.details?.namespace_permissions) && (
             <div className="mb-4">
-              <div className="text-sm text-gray-400 mb-2 px-2">
+              <div className="mb-2 px-2 text-sm text-gray-400">
                 Capabilities
               </div>
               <div className="border-l-2 border-blue-500/30 pl-2">
@@ -165,10 +160,10 @@ export function NodeDetailsCard({
                     <AccordionItem
                       key={`${sourceId}-${targetId}`}
                       value={`${sourceId}-${targetId}`}
-                      className="border bg-accent mb-2"
+                      className="bg-accent mb-2 border"
                     >
-                      <AccordionTrigger className="px-4 py-3 hover:no-underline hover:bg-gray-700/50 text-left">
-                        <div className="flex flex-col gap-1 w-full pr-2">
+                      <AccordionTrigger className="px-4 py-3 text-left hover:bg-gray-700/50 hover:no-underline">
+                        <div className="flex w-full flex-col gap-1 pr-2">
                           <div className="flex items-center justify-between">
                             <span className="font-medium text-white">
                               {details?.namespace_permissions
@@ -178,14 +173,16 @@ export function NodeDetailsCard({
                           </div>
                           <GraphSheetDetailsLinkButtons
                             grantor_key={details?.permissions.grantorAccountId}
-                            grantee_key={details?.permissions.granteeAccountId}
+                            grantee_key={
+                              details?.permissions.granteeAccountId || undefined
+                            }
                             permission_id={String(
                               details?.permissions.permissionId,
                             )}
                           />
                         </div>
                       </AccordionTrigger>
-                      <AccordionContent className="px-4 pb-4 pt-2 space-y-3">
+                      <AccordionContent className="space-y-3 px-4 pb-4 pt-2">
                         {details && (
                           <>
                             <div className="grid grid-cols-2 gap-2">
@@ -228,7 +225,7 @@ export function NodeDetailsCard({
                                       `?id=permission-${details.permissions.permissionId}`,
                                     );
                                   }}
-                                  className="text-sm text-blue-400 hover:text-blue-300 cursor-pointer underline"
+                                  className="cursor-pointer text-sm text-blue-400 underline hover:text-blue-300"
                                 >
                                   {smallAddress(
                                     String(details.permissions.permissionId),
@@ -272,7 +269,7 @@ export function NodeDetailsCard({
                                       Capability path
                                       {paths.length > 1 ? "s" : ""}
                                     </span>
-                                    <div className="text-sm text-gray-300 font-mono break-all space-y-1">
+                                    <div className="space-y-1 break-all font-mono text-sm text-gray-300">
                                       {paths.map((path, index) => (
                                         <div key={index}>
                                           <ShortenedCapabilityPath
@@ -297,7 +294,7 @@ export function NodeDetailsCard({
           {/* Emissions section */}
           {permissions.some((p) => p.details?.emission_permissions) && (
             <div>
-              <div className="text-sm text-gray-400 mb-2 px-2">Emissions</div>
+              <div className="mb-2 px-2 text-sm text-gray-400">Emissions</div>
               <div className="border-l-2 border-green-500/30 pl-2">
                 {permissions
                   .filter((p) => p.details?.emission_permissions)
@@ -305,10 +302,10 @@ export function NodeDetailsCard({
                     <AccordionItem
                       key={`${sourceId}-${targetId}`}
                       value={`${sourceId}-${targetId}`}
-                      className="border bg-accent mb-2"
+                      className="bg-accent mb-2 border"
                     >
-                      <AccordionTrigger className="px-4 py-3 hover:no-underline hover:bg-gray-700/50 text-left">
-                        <div className="flex flex-col gap-1 w-full pr-2">
+                      <AccordionTrigger className="px-4 py-3 text-left hover:bg-gray-700/50 hover:no-underline">
+                        <div className="flex w-full flex-col gap-1 pr-2">
                           <div className="flex items-center justify-between">
                             <span className="font-medium text-white">
                               {details?.emission_permissions
@@ -318,14 +315,16 @@ export function NodeDetailsCard({
                           </div>
                           <GraphSheetDetailsLinkButtons
                             grantor_key={details?.permissions.grantorAccountId}
-                            grantee_key={details?.permissions.granteeAccountId}
+                            grantee_key={
+                              details?.permissions.granteeAccountId || undefined
+                            }
                             permission_id={String(
                               details?.permissions.permissionId,
                             )}
                           />
                         </div>
                       </AccordionTrigger>
-                      <AccordionContent className="px-4 pb-4 pt-2 space-y-3">
+                      <AccordionContent className="space-y-3 px-4 pb-4 pt-2">
                         {details && (
                           <>
                             <div className="grid grid-cols-2 gap-2">
@@ -376,7 +375,7 @@ export function NodeDetailsCard({
                                       `?id=permission-${details.permissions.permissionId}`,
                                     );
                                   }}
-                                  className="text-sm text-blue-400 hover:text-blue-300 cursor-pointer underline"
+                                  className="cursor-pointer text-sm text-blue-400 underline hover:text-blue-300"
                                 >
                                   {smallAddress(
                                     String(details.permissions.permissionId),
@@ -398,7 +397,7 @@ export function NodeDetailsCard({
                                       variant="ghost"
                                       className="h-auto p-0"
                                     >
-                                      <span className="text-blue-400 hover:text-blue-300 cursor-pointer underline">
+                                      <span className="cursor-pointer text-blue-400 underline hover:text-blue-300">
                                         {smallAddress(
                                           String(
                                             details.emission_stream_allocations
@@ -433,7 +432,7 @@ export function NodeDetailsCard({
             renderPermissionGroup(
               groupedPermissions.delegated,
               "Delegated",
-              <ArrowUpRight className="h-4 w-4 text-muted-foreground" />,
+              <ArrowUpRight className="text-muted-foreground h-4 w-4" />,
             )}
 
           {/* Received Permissions - only show if there are received permissions */}
@@ -441,11 +440,11 @@ export function NodeDetailsCard({
             renderPermissionGroup(
               groupedPermissions.received,
               "Received",
-              <ArrowDownLeft className="h-4 w-4 text-muted-foreground" />,
+              <ArrowDownLeft className="text-muted-foreground h-4 w-4" />,
             )}
         </Accordion>
       ) : (
-        <div className="text-gray-500 text-center mt-8">
+        <div className="mt-8 text-center text-gray-500">
           No permissions found for this agent
         </div>
       )}
@@ -455,18 +454,18 @@ export function NodeDetailsCard({
   if (!graphData) return null;
 
   return (
-    <Card className="w-full flex-1 flex flex-col z-50 border-none">
-      <Tabs defaultValue="permissions" className="w-full flex flex-col flex-1">
-        <TabsList className="grid w-full grid-cols-2 mb-4">
+    <Card className="z-50 flex w-full flex-1 flex-col border-none">
+      <Tabs defaultValue="permissions" className="flex w-full flex-1 flex-col">
+        <TabsList className="mb-4 grid w-full grid-cols-2">
           <TabsTrigger value="permissions">Permissions</TabsTrigger>
           <TabsTrigger value="signals">Signals</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="permissions" className="flex-1 mt-0">
+        <TabsContent value="permissions" className="mt-0 flex-1">
           <PermissionsContent />
         </TabsContent>
 
-        <TabsContent value="signals" className="flex-1 mt-0">
+        <TabsContent value="signals" className="mt-0 flex-1">
           <ScrollArea className="h-[calc(100vh-32rem)] pb-4 md:pb-0">
             <GraphSheetDetailsSignalsAccordion selectedNode={selectedNode} />
           </ScrollArea>

--- a/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-fields/allocation-field.tsx
+++ b/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-fields/allocation-field.tsx
@@ -1,11 +1,5 @@
-import React, { useCallback, useEffect } from "react";
-
-import { Plus, Trash2 } from "lucide-react";
-import { useFieldArray } from "react-hook-form";
-
 import type { Api } from "@torus-network/sdk/chain";
 import { checkSS58 } from "@torus-network/sdk/types";
-
 import { useTorus } from "@torus-ts/torus-provider";
 import { Button } from "@torus-ts/ui/components/button";
 import {
@@ -16,11 +10,12 @@ import {
   FormMessage,
 } from "@torus-ts/ui/components/form";
 import { Input } from "@torus-ts/ui/components/input";
-
 import { useAvailableStreams } from "~/hooks/use-available-streams";
-import { useMultipleAccountEmissions } from "~/hooks/use-multiple-account-emissions";
-import { calculateEmissionValue } from "~/utils/calculate-emission-value";
-
+import { useMultipleAccountStreams } from "~/hooks/use-multiple-account-streams";
+import { calculateIndividualStreamValue } from "~/utils/calculate-emission-value";
+import { Plus, Trash2 } from "lucide-react";
+import React, { useCallback, useEffect } from "react";
+import { useFieldArray } from "react-hook-form";
 import type { CreateEmissionPermissionForm } from "../create-emission-permission-form-schema";
 
 interface AllocationFieldProps {
@@ -46,12 +41,12 @@ export function AllocationField({
     checkSS58IfDefined(selectedAccountAddress),
   );
 
-  const emissionsData = useMultipleAccountEmissions({
+  const streamsData = useMultipleAccountStreams({
     accountIds: selectedAccount?.address ? [selectedAccount.address] : [],
   });
 
-  const accountEmissions = selectedAccount?.address
-    ? emissionsData[selectedAccount.address]
+  const accountStreams = selectedAccount?.address
+    ? streamsData[selectedAccount.address]
     : null;
 
   const {
@@ -112,7 +107,7 @@ export function AllocationField({
                 }
                 disabled={!isAccountConnected}
               >
-                <Plus className="h-4 w-4 mr-2" />
+                <Plus className="mr-2 h-4 w-4" />
                 Add Stream
               </Button>
             </div>
@@ -120,8 +115,8 @@ export function AllocationField({
         )}
 
         {streamFields.length === 0 && (
-          <div className="text-center py-4 border-2 border-dashed rounded-md">
-            <p className="text-sm text-muted-foreground mb-2">
+          <div className="rounded-md border-2 border-dashed py-4 text-center">
+            <p className="text-muted-foreground mb-2 text-sm">
               No streams added yet
             </p>
             <Button
@@ -136,7 +131,7 @@ export function AllocationField({
               }
               disabled={!isAccountConnected}
             >
-              <Plus className="h-4 w-4 mr-2" />
+              <Plus className="mr-2 h-4 w-4" />
               Add First Stream
             </Button>
           </div>
@@ -146,10 +141,22 @@ export function AllocationField({
           return (
             <div
               key={field.id}
-              className="grid gap-3 px-4 pt-4 pb-2 border rounded-md"
+              className="grid gap-3 rounded-md border px-4 pb-2 pt-4"
             >
               <div className="flex items-center justify-between">
-                <h4 className="text-sm font-medium">Stream {index + 1}</h4>
+                <h4 className="text-sm font-medium">
+                  Stream {index + 1} (
+                  {calculateIndividualStreamValue(
+                    Number(
+                      form.watch(`allocation.streams.${index}.percentage`),
+                    ) || 0,
+                    form.watch(`allocation.streams.${index}.streamId`) || "",
+                    accountStreams,
+                    isAccountConnected,
+                    selectedAccount?.address,
+                  )}
+                  )
+                </h4>
                 {streamFields.length > 1 && (
                   <Button
                     type="button"
@@ -201,14 +208,6 @@ export function AllocationField({
                           disabled={!isAccountConnected}
                         />
                       </FormControl>
-                      <div className="text-xs text-green-400 mt-1">
-                        {calculateEmissionValue(
-                          Number(percentageField.value) || 0,
-                          accountEmissions,
-                          isAccountConnected,
-                          selectedAccount?.address,
-                        )}
-                      </div>
                       <div className="min-h-[20px]">
                         <FormMessage />
                       </div>
@@ -222,31 +221,50 @@ export function AllocationField({
 
         {/* Total Emission Display */}
         {streamFields.length > 0 && (
-          <div className="mt-4 p-3 bg-muted/20 rounded-md border">
+          <div className="bg-muted/20 mt-4 rounded-md border p-3">
             <div className="text-sm">
               <span className="text-muted-foreground font-medium">
                 Total Stream Allocation:{" "}
               </span>
-              <span className="text-green-400 font-semibold">
+              <span className="font-semibold text-green-400">
                 {(() => {
-                  const totalPercentage = streamFields.reduce(
-                    (total, _, index) => {
-                      const percentage =
-                        Number(
-                          form.watch(`allocation.streams.${index}.percentage`),
-                        ) || 0;
-                      return total + percentage;
-                    },
-                    0,
-                  );
+                  if (
+                    !isAccountConnected ||
+                    !selectedAccount?.address ||
+                    !accountStreams ||
+                    accountStreams.isLoading ||
+                    accountStreams.isError
+                  ) {
+                    return "calculating...";
+                  }
 
-                  return calculateEmissionValue(
-                    totalPercentage,
-                    accountEmissions,
-                    isAccountConnected,
-                    selectedAccount?.address,
-                  );
-                })()}
+                  // Calculate total from individual streams that are configured
+                  let totalStreamCapacity = 0;
+                  let totalAllocated = 0;
+
+                  streamFields.forEach((_, index) => {
+                    const streamId = form.watch(
+                      `allocation.streams.${index}.streamId`,
+                    );
+                    const percentage =
+                      Number(
+                        form.watch(`allocation.streams.${index}.percentage`),
+                      ) || 0;
+
+                    if (streamId) {
+                      const stream = accountStreams.incoming.streams.find(
+                        (s) => s.streamId === streamId,
+                      );
+                      if (stream) {
+                        const streamCapacity = stream.tokensPerWeek.toNumber();
+                        totalStreamCapacity += streamCapacity;
+                        totalAllocated += (streamCapacity * percentage) / 100;
+                      }
+                    }
+                  });
+
+                  return `${totalAllocated.toFixed(2)}/${totalStreamCapacity.toFixed(2)} TORUS/week`;
+                })()}{" "}
               </span>
             </div>
           </div>

--- a/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-fields/targets-field.tsx
+++ b/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-fields/targets-field.tsx
@@ -1,10 +1,4 @@
-import React from "react";
-
-import { Plus, Trash2 } from "lucide-react";
-import { useFieldArray } from "react-hook-form";
-
 import type { SS58Address } from "@torus-network/sdk/types";
-
 import { useTorus } from "@torus-ts/torus-provider";
 import { Button } from "@torus-ts/ui/components/button";
 import {
@@ -15,11 +9,12 @@ import {
   FormMessage,
 } from "@torus-ts/ui/components/form";
 import { Input } from "@torus-ts/ui/components/input";
-
 import { FormAddressField } from "~/app/_components/address-field";
 import { useMultipleAccountEmissions } from "~/hooks/use-multiple-account-emissions";
 import { calculateEmissionValue } from "~/utils/calculate-emission-value";
-
+import { Plus, Trash2 } from "lucide-react";
+import React from "react";
+import { useFieldArray } from "react-hook-form";
 import type { CreateEmissionPermissionForm } from "../create-emission-permission-form-schema";
 
 interface TargetsFieldProps {
@@ -66,7 +61,7 @@ export function TargetsField({ form, isAccountConnected }: TargetsFieldProps) {
           }
           disabled={!isAccountConnected}
         >
-          <Plus className="h-4 w-4 mr-2" />
+          <Plus className="mr-2 h-4 w-4" />
           Add Target
         </Button>
       </div>
@@ -74,10 +69,29 @@ export function TargetsField({ form, isAccountConnected }: TargetsFieldProps) {
       {targetFields.map((field, index) => (
         <div
           key={field.id}
-          className="grid gap-3 pt-4 px-4 pb-2 border rounded-md relative"
+          className="relative grid gap-3 rounded-md border px-4 pb-2 pt-4"
         >
           <div className="flex items-center justify-between">
-            <h4 className="text-sm font-medium">Target {index + 1}</h4>
+            <h4 className="text-sm font-medium">
+              Target {index + 1} (
+              {(() => {
+                const targetWeight =
+                  Number(form.watch(`targets.${index}.weight`)) || 0;
+                const targetPercentage =
+                  totalStreamPercentage > 0
+                    ? (targetWeight / 100) * totalStreamPercentage
+                    : 0;
+
+                return `${targetWeight}% of ${totalStreamPercentage}% = ${calculateEmissionValue(
+                  targetPercentage,
+                  accountEmissions,
+                  isAccountConnected,
+                  selectedAccount?.address,
+                  "value-only",
+                )}`;
+              })()}
+              )
+            </h4>
             {targetFields.length > 1 && (
               <Button
                 type="button"
@@ -91,7 +105,7 @@ export function TargetsField({ form, isAccountConnected }: TargetsFieldProps) {
             )}
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-[1fr,120px] gap-3">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr,120px]">
             <FormField
               control={form.control}
               name={`targets.${index}.account`}
@@ -122,22 +136,6 @@ export function TargetsField({ form, isAccountConnected }: TargetsFieldProps) {
                       className="h-[2.6rem]"
                     />
                   </FormControl>
-                  <div className="text-xs text-green-400 mt-1">
-                    {(() => {
-                      const targetWeight = Number(weightField.value) || 0;
-                      const targetPercentage =
-                        totalStreamPercentage > 0
-                          ? (targetWeight / 100) * totalStreamPercentage
-                          : 0;
-
-                      return `${targetWeight}% of ${totalStreamPercentage}% = ${calculateEmissionValue(
-                        targetPercentage,
-                        accountEmissions,
-                        isAccountConnected,
-                        selectedAccount?.address,
-                      )}`;
-                    })()}
-                  </div>
                   <div className="min-h-[20px]">
                     <FormMessage />
                   </div>

--- a/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-permission-form-utils.ts
+++ b/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-permission-form-utils.ts
@@ -1,16 +1,15 @@
 import type {
   DistributionControl,
-  EmissionAllocation,
   EnforcementAuthority,
   PermissionDuration,
   RevocationTerms,
+  StreamAllocation,
 } from "@torus-network/sdk/chain";
 import type { SS58Address } from "@torus-network/sdk/types";
-
 import type { CreateEmissionPermissionFormData } from "./create-emission-permission-form-schema";
 
 export function transformFormDataToSDK(data: CreateEmissionPermissionFormData) {
-  let allocation: EmissionAllocation;
+  let allocation: StreamAllocation;
   if (data.allocation.type === "FixedAmount") {
     allocation = {
       FixedAmount: BigInt(parseFloat(data.allocation.amount) * 1e6),
@@ -26,7 +25,7 @@ export function transformFormDataToSDK(data: CreateEmissionPermissionFormData) {
     };
   }
 
-  const targets = data.targets.map(
+  const recipients = data.targets.map(
     (target) =>
       [target.account as SS58Address, parseInt(target.weight)] as [
         SS58Address,
@@ -98,7 +97,7 @@ export function transformFormDataToSDK(data: CreateEmissionPermissionFormData) {
 
   return {
     allocation,
-    targets,
+    recipients,
     distribution,
     duration,
     revocation,

--- a/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-permission-form.tsx
+++ b/apps/torus-portal/src/app/(pages)/permissions/create-permission/emission/_components/create-emission-permission-form.tsx
@@ -1,21 +1,16 @@
 "use client";
 
-import { useCallback } from "react";
-
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2 } from "lucide-react";
-import { useForm } from "react-hook-form";
-
-import { delegateEmissionPermission } from "@torus-network/sdk/chain";
-import type { SS58Address } from "@torus-network/sdk/types";
-
+import { delegateStreamPermission } from "@torus-network/sdk/chain";
 import { useTorus } from "@torus-ts/torus-provider";
 import { useSendTransaction } from "@torus-ts/torus-provider/use-send-transaction";
 import { Button } from "@torus-ts/ui/components/button";
 import { Form } from "@torus-ts/ui/components/form";
 import { WalletConnectionWarning } from "@torus-ts/ui/components/wallet-connection-warning";
 import { useToast } from "@torus-ts/ui/hooks/use-toast";
-
+import { Loader2 } from "lucide-react";
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
 import { AllocationField } from "./create-emission-fields/allocation-field";
 import { DistributionField } from "./create-emission-fields/distribution-field";
 import { DurationField } from "./create-emission-fields/duration-field";
@@ -85,10 +80,14 @@ export function CreateEmissionPermissionForm() {
       const transformedData = transformFormDataToSDK(data);
 
       const [sendErr, sendRes] = await sendTx(
-        delegateEmissionPermission({
+        delegateStreamPermission({
           api,
-          recipient: selectedAccount.address as SS58Address,
-          ...transformedData,
+          recipients: transformedData.recipients,
+          allocation: transformedData.allocation,
+          distribution: transformedData.distribution,
+          duration: transformedData.duration,
+          revocation: transformedData.revocation,
+          enforcement: transformedData.enforcement,
         }),
       );
 

--- a/apps/torus-portal/src/app/(pages)/permissions/manage-permission/_components/edit-permission-form.tsx
+++ b/apps/torus-portal/src/app/(pages)/permissions/manage-permission/_components/edit-permission-form.tsx
@@ -1,14 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useSearchParams } from "next/navigation";
-import { useForm } from "react-hook-form";
-import type { z } from "zod";
-
-import { updateEmissionPermission } from "@torus-network/sdk/chain";
-
+import { updateStreamPermission } from "@torus-network/sdk/chain";
 import type { InferSelectModel } from "@torus-ts/db";
 import type {
   emissionPermissionsSchema,
@@ -22,11 +15,13 @@ import { Form } from "@torus-ts/ui/components/form";
 import { WalletConnectionWarning } from "@torus-ts/ui/components/wallet-connection-warning";
 import { useToast } from "@torus-ts/ui/hooks/use-toast";
 import { cn } from "@torus-ts/ui/lib/utils";
-
 import { PermissionSelector } from "~/app/_components/permission-selector";
 import PortalFormHeader from "~/app/_components/portal-form-header";
 import { PortalFormSeparator } from "~/app/_components/portal-form-separator";
-
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import type { z } from "zod";
 import { DistributionControlField } from "./edit-permission-fields/distribution-control-field";
 import { StreamsField } from "./edit-permission-fields/streams-field";
 import { TargetsField } from "./edit-permission-fields/targets-field";
@@ -75,7 +70,7 @@ export function EditPermissionForm({
     selectedAccount,
     wsEndpoint,
     wallet: torusApi,
-    transactionType: "Update Emission Permission",
+    transactionType: "Update Stream Permission",
   });
   const [selectedPermissionId, setSelectedPermissionId] = useState<string>("");
   const [hasLoadedPermission, setHasLoadedPermission] = useState(false);
@@ -136,7 +131,7 @@ export function EditPermissionForm({
     const sdkData = prepareFormDataForSDK(data);
 
     const [sendErr, sendRes] = await sendTx(
-      updateEmissionPermission({
+      updateStreamPermission({
         api,
         ...sdkData,
       }),

--- a/apps/torus-portal/src/app/(pages)/permissions/manage-permission/_components/edit-permission-utils.ts
+++ b/apps/torus-portal/src/app/(pages)/permissions/manage-permission/_components/edit-permission-utils.ts
@@ -1,6 +1,3 @@
-import type { UseFormReset } from "react-hook-form";
-import { match } from "rustie";
-
 import type {
   Api,
   PermissionContract,
@@ -9,7 +6,8 @@ import type {
 } from "@torus-network/sdk/chain";
 import { queryPermission } from "@torus-network/sdk/chain";
 import type { SS58Address } from "@torus-network/sdk/types";
-
+import type { UseFormReset } from "react-hook-form";
+import { match } from "rustie";
 import type { PermissionWithDetails } from "./edit-permission-form";
 import type {
   DistributionControlFormData,
@@ -45,11 +43,11 @@ function transformPermissionToFormData(
 ): Partial<EditPermissionFormData> {
   const formData: Partial<EditPermissionFormData> = {};
 
-  // Extract emission permission data
+  // Extract stream permission data
   match(permission.scope)({
-    Emission: (emissionScope) => {
-      if (emissionScope.targets.size > 0) {
-        formData.newTargets = Array.from(emissionScope.targets.entries()).map(
+    Stream: (streamScope) => {
+      if (streamScope.recipients.size > 0) {
+        formData.newTargets = Array.from(streamScope.recipients.entries()).map(
           ([address, weight]) => ({
             address,
             percentage: Number(weight), // SDK uses weight, but we display as percentage
@@ -57,7 +55,7 @@ function transformPermissionToFormData(
         );
       }
 
-      match(emissionScope.allocation)({
+      match(streamScope.allocation)({
         Streams: (streamsMap) => {
           if (streamsMap.size > 0) {
             formData.newStreams = Array.from(streamsMap.entries()).map(
@@ -73,7 +71,7 @@ function transformPermissionToFormData(
         },
       });
 
-      const distribution = emissionScope.distribution;
+      const distribution = streamScope.distribution;
       formData.newDistributionControl = match(distribution)({
         Manual: () => ({ Manual: null }),
         Automatic: (threshold) =>
@@ -85,10 +83,10 @@ function transformPermissionToFormData(
       });
     },
     Curator: () => {
-      // Curator permissions don't have emission data
+      // Curator permissions don't have stream data
     },
     Namespace: () => {
-      // Namespace permissions don't have emission data
+      // Namespace permissions don't have stream data
     },
   });
 
@@ -172,7 +170,7 @@ export function prepareFormDataForSDK(data: EditPermissionFormData) {
 
   return {
     permissionId: permissionId as PermissionId,
-    newTargets: sdkTargets,
+    newRecipients: sdkTargets,
     newStreams: sdkStreams,
     newDistributionControl,
   };

--- a/apps/torus-portal/src/hooks/use-multiple-account-emissions.ts
+++ b/apps/torus-portal/src/hooks/use-multiple-account-emissions.ts
@@ -1,17 +1,14 @@
-import { useMemo } from "react";
-
 import type { TorAmount } from "@torus-network/torus-utils/torus/token";
 import {
   formatTorusToken,
   makeTorAmount,
 } from "@torus-network/torus-utils/torus/token";
-
 import { api } from "~/trpc/react";
-
+import { useMemo } from "react";
 import { useMultipleAccountStreams } from "./use-multiple-account-streams";
 import { useTokensPerWeek } from "./use-tokens-per-week";
 
-interface AccountEmissionData {
+export interface AccountEmissionData {
   isLoading: boolean;
   isError: boolean;
   root: {

--- a/apps/torus-portal/src/utils/calculate-emission-value.ts
+++ b/apps/torus-portal/src/utils/calculate-emission-value.ts
@@ -1,12 +1,15 @@
+import type { TorAmount } from "@torus-network/torus-utils/torus/token";
 import { makeTorAmount } from "@torus-network/torus-utils/torus/token";
-
 import type { AccountEmissionData } from "~/hooks/use-multiple-account-emissions";
+
+type DisplayMode = "full" | "fraction" | "value-only";
 
 export function calculateEmissionValue(
   percentage: number,
   accountEmissions: AccountEmissionData | null | undefined,
   isAccountConnected: boolean,
   selectedAccountAddress: string | undefined,
+  displayMode: DisplayMode = "full",
 ): string {
   if (
     !isAccountConnected ||
@@ -18,19 +21,110 @@ export function calculateEmissionValue(
     return "calculating...";
   }
 
-  if (percentage === 0) return "0.00 TORUS/week";
-
   const percentageFactor = percentage / 100;
   const incomingEmissions =
     accountEmissions.streams.incoming.tokensPerWeek.plus(
       accountEmissions.root.tokensPerWeek,
     );
+  const totalEmissions = incomingEmissions.toNumber();
 
   const calculatedValue = incomingEmissions.multipliedBy(
     makeTorAmount(percentageFactor),
   );
   const value = calculatedValue.toNumber();
 
-  if (value < 0.01 && value > 0) return "< 0.01 TORUS/week";
-  return `${value.toFixed(2)} TORUS/week`;
+  // Handle zero percentage case
+  if (percentage === 0) {
+    switch (displayMode) {
+      case "fraction":
+        return `0 / ${totalEmissions.toFixed(2)}`;
+      case "value-only":
+        return "0.00 TORUS/week";
+      case "full":
+      default:
+        return "0.00 TORUS/week";
+    }
+  }
+
+  // Format the value
+  let formattedValue: string;
+  if (value < 0.01 && value > 0) {
+    formattedValue = "< 0.01";
+  } else {
+    formattedValue = value.toFixed(2);
+  }
+
+  // Return based on display mode
+  switch (displayMode) {
+    case "fraction":
+      return `${formattedValue} / ${totalEmissions.toFixed(2)}`;
+    case "value-only":
+      return `${formattedValue} TORUS/week`;
+    case "full":
+    default:
+      return `${formattedValue} TORUS/week`;
+  }
+}
+
+interface StreamData {
+  permissionId: string;
+  streamId: string;
+  tokensPerWeek: TorAmount;
+}
+
+interface AccountStreamsResult {
+  incoming: {
+    streams: StreamData[];
+  };
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function calculateIndividualStreamValue(
+  percentage: number,
+  streamId: string,
+  accountStreams: AccountStreamsResult | null | undefined,
+  isAccountConnected: boolean,
+  selectedAccountAddress: string | undefined,
+): string {
+  if (
+    !isAccountConnected ||
+    !selectedAccountAddress ||
+    !accountStreams ||
+    accountStreams.isLoading ||
+    accountStreams.isError
+  ) {
+    return "calculating...";
+  }
+
+  // Find the specific stream in the incoming streams
+  const specificStream = accountStreams.incoming.streams.find(
+    (stream) => stream.streamId === streamId,
+  );
+
+  if (!specificStream) {
+    return "0/0 TORUS/week";
+  }
+
+  const totalStreamValue = specificStream.tokensPerWeek.toNumber();
+
+  if (percentage === 0) {
+    return `0/${totalStreamValue.toFixed(2)} TORUS/week`;
+  }
+
+  const percentageFactor = percentage / 100;
+  const calculatedValue = specificStream.tokensPerWeek.multipliedBy(
+    makeTorAmount(percentageFactor),
+  );
+  const allocatedValue = calculatedValue.toNumber();
+
+  // Format allocated value
+  let formattedAllocated: string;
+  if (allocatedValue < 0.01 && allocatedValue > 0) {
+    formattedAllocated = "< 0.01";
+  } else {
+    formattedAllocated = allocatedValue.toFixed(2);
+  }
+
+  return `${formattedAllocated}/${totalStreamValue.toFixed(2)} TORUS/week`;
 }

--- a/apps/torus-worker/src/workers/agent-fetcher.ts
+++ b/apps/torus-worker/src/workers/agent-fetcher.ts
@@ -2,13 +2,13 @@ import { match } from "rustie";
 
 import type {
   AccumulatedStreamEntry,
-  EmissionScope,
   LastBlock,
   NamespaceScope,
   PermissionContract,
   PermissionId,
   Proposal,
   StreamId,
+  StreamScope,
 } from "@torus-network/sdk/chain";
 import {
   queryAgents,
@@ -126,7 +126,7 @@ async function cleanPermissions(
  */
 function streamToDatabase(
   permissionId: PermissionId,
-  stream: EmissionScope, // Using EmissionScope for backward compatibility
+  stream: StreamScope,
   delegator: SS58Address,
   streamAccumulations: AccumulatedStreamEntry[],
   atBlock: number,

--- a/atlas/migrations/20250828184403_chain-spec-24.sql
+++ b/atlas/migrations/20250828184403_chain-spec-24.sql
@@ -1,0 +1,6 @@
+-- Modify "emission_permissions" table
+ALTER TABLE "public"."emission_permissions" ADD COLUMN "weight_setter" character varying(256)[] NOT NULL, ADD COLUMN "recipient_manager" character varying(256)[] NOT NULL;
+-- Modify "namespace_permissions" table
+ALTER TABLE "public"."namespace_permissions" ADD COLUMN "recipient" character varying(256) NOT NULL;
+-- Modify "permissions" table
+ALTER TABLE "public"."permissions" ALTER COLUMN "grantee_account_id" DROP NOT NULL;

--- a/atlas/migrations/atlas.sum
+++ b/atlas/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:AambhSfqO7jHDXh9AgaPKTIKV3dpWIznkj2G2Vmo1dY=
+h1:7eVJTsL2+B8+Pree6uC3O7d5booNoqpfe1odH+ZADXU=
 20250331002414.sql h1:fO+bA46lvxVUFMADmjjiAsA57EqYc+NSmcWu+KxRoEw=
 20250331002504.sql h1:5o1HYuLb8zySkJZIoiVeIwk/FDTGxBoFA9jFsM1t7cw=
 20250331020820.sql h1:arLqO+apCTs27kacBxpD/s/vrRkRkhB+HXRiVuIeDmU=
@@ -18,3 +18,4 @@ h1:AambhSfqO7jHDXh9AgaPKTIKV3dpWIznkj2G2Vmo1dY=
 20250814170621_fix-accumulatedStreamAmounts-pk.sql h1:gdvFVfFjgo1z4H+XYoBfyrOtX3/3Nwl5H/rItI73ge0=
 20250814214020_explode-my-problems.sql h1:bW8TIVMQKHXy6yMiLQQrngDW2tabNUQZxISBvy4CFz4=
 20250814214240_recreate-problem.sql h1:PppQzKBOvlp+Qvjp9+aR1kHN+O4ldgkxHiWuCHzo8Hs=
+20250828184403_chain-spec-24.sql h1:gGfWnUMuLTwrPQkd9y59uGSrtdl9mocej/jMA6F2myk=

--- a/packages/api/src/router/permission/permission.ts
+++ b/packages/api/src/router/permission/permission.ts
@@ -1,7 +1,10 @@
 import type { TRPCRouterRecord } from "@trpc/server";
 import { z } from "zod";
 
-import { queryEmissionPermissions } from "@torus-network/sdk/chain";
+import {
+  queryStreamPermissions,
+  type StreamContract,
+} from "@torus-network/sdk/chain";
 import { SS58_SCHEMA } from "@torus-network/sdk/types";
 import type { RemAmount } from "@torus-network/torus-utils/torus/token";
 
@@ -937,7 +940,7 @@ export const permissionRouter = {
       const api = await ctx.wsAPI;
 
       const [permissionsError, emissionPermissions] =
-        await queryEmissionPermissions(api, (permission) => {
+        await queryStreamPermissions(api, (permission: StreamContract) => {
           return permission.scope.recipients.has(input.accountId);
         });
 

--- a/packages/api/src/router/permission/permission.ts
+++ b/packages/api/src/router/permission/permission.ts
@@ -1,13 +1,7 @@
-import type { TRPCRouterRecord } from "@trpc/server";
-import { z } from "zod";
-
-import {
-  queryStreamPermissions,
-  type StreamContract,
-} from "@torus-network/sdk/chain";
+import type { StreamContract } from "@torus-network/sdk/chain";
+import { queryStreamPermissions } from "@torus-network/sdk/chain";
 import { SS58_SCHEMA } from "@torus-network/sdk/types";
 import type { RemAmount } from "@torus-network/torus-utils/torus/token";
-
 import { and, eq, gte, isNotNull, isNull, lte, or, sql } from "@torus-ts/db";
 import type { createDb } from "@torus-ts/db/client";
 import {
@@ -19,7 +13,8 @@ import {
   namespacePermissionsSchema,
   permissionsSchema,
 } from "@torus-ts/db/schema";
-
+import type { TRPCRouterRecord } from "@trpc/server";
+import { z } from "zod";
 import { publicProcedure } from "../../trpc";
 
 type StreamsPerBlockResult = Record<

--- a/packages/torus-sdk-ts/src/chain/permission0/permission0-extrinsics.ts
+++ b/packages/torus-sdk-ts/src/chain/permission0/permission0-extrinsics.ts
@@ -6,11 +6,11 @@ import type { AccountId32, H256, Percent } from "@polkadot/types/interfaces";
 import type { SS58Address } from "../../types/index.js";
 import type {
   DistributionControl,
-  EmissionAllocation,
   EnforcementAuthority,
   PermissionDuration,
   PermissionId,
   RevocationTerms,
+  StreamAllocation,
   StreamId,
 } from "./permission0-types.js";
 
@@ -67,7 +67,7 @@ export function delegateNamespacePermission({
 export interface DelegateStreamPermission {
   api: ApiPromise;
   recipients: [SS58Address, number][];
-  allocation: EmissionAllocation;
+  allocation: StreamAllocation;
   distribution: DistributionControl;
   duration: PermissionDuration;
   revocation: RevocationTerms;

--- a/packages/torus-sdk-ts/src/chain/permission0/permission0-storage.ts
+++ b/packages/torus-sdk-ts/src/chain/permission0/permission0-storage.ts
@@ -24,9 +24,9 @@ import { SbQueryError } from "../common/fees.js";
 import type {
   AccumulatedStreamEntry,
   CuratorPermissions,
-  StreamContract,
   PermissionContract,
   PermissionId,
+  StreamContract,
   StreamId,
 } from "./permission0-types.js";
 import {
@@ -212,9 +212,6 @@ export async function queryStreamPermissions(
 
   return makeOk(streamPermissions);
 }
-
-// Backward compatibility alias
-export const queryEmissionPermissions = queryStreamPermissions;
 
 /**
  * Query all namespace permissions from the blockchain.
@@ -562,7 +559,7 @@ export const extractRecipientsFromPermission = (
 };
 
 /**
- * Check if a permission is enabled by verifying that accumulating = true in an EmissionScope
+ * Check if a permission is enabled by verifying that accumulating = true in a StreamScope
  */
 export async function isPermissionEnabled(
   api: Api,

--- a/packages/torus-sdk-ts/src/chain/permission0/permission0-types.ts
+++ b/packages/torus-sdk-ts/src/chain/permission0/permission0-types.ts
@@ -15,7 +15,6 @@ import {
   sb_percent,
   sb_struct,
 } from "../../types/index.js";
-
 import { sb_namespace_path } from "../torus0/torus0-types.js";
 
 export const PERMISSION_ID_SCHEMA = sb_h256;
@@ -81,10 +80,6 @@ export const STREAM_SCOPE_SCHEMA = sb_struct({
   weightSetters: sb_array(sb_address), // BoundedBTreeSet serialized as array (camelCase in JSON)
   accumulating: sb_bool,
 });
-
-// Backward compatibility aliases
-export const EMISSION_ALLOCATION_SCHEMA = STREAM_ALLOCATION_SCHEMA;
-export const EMISSION_SCOPE_SCHEMA = STREAM_SCOPE_SCHEMA;
 
 // ---- Curator Types ----
 
@@ -181,9 +176,3 @@ export type StreamContract = z.infer<typeof STREAM_CONTRACT_SCHEMA>;
 export type StreamAllocation = z.infer<typeof STREAM_ALLOCATION_SCHEMA>;
 export type DistributionControl = z.infer<typeof DISTRIBUTION_CONTROL_SCHEMA>;
 export type StreamScope = z.infer<typeof STREAM_SCOPE_SCHEMA>;
-
-// Backward compatibility aliases
-export const EMISSION_CONTRACT_SCHEMA = STREAM_CONTRACT_SCHEMA;
-export type EmissionContract = StreamContract;
-export type EmissionAllocation = StreamAllocation;
-export type EmissionScope = StreamScope;

--- a/packages/torus-sdk-ts/src/extrinsics.ts
+++ b/packages/torus-sdk-ts/src/extrinsics.ts
@@ -6,19 +6,16 @@ import type { ApiPromise, SubmittableResult } from "@polkadot/api";
 import type { SubmittableExtrinsic } from "@polkadot/api-base/types";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { DispatchError, ExtrinsicStatus } from "@polkadot/types/interfaces";
-import Emittery from "emittery";
-import type { Enum } from "rustie";
-import { match } from "rustie";
-import { assert } from "tsafe";
-import { z } from "zod";
-
-import { AsyncPushStream } from "@torus-network/torus-utils/async";
 import { chainErr, ParseError } from "@torus-network/torus-utils/error";
 import type { Result } from "@torus-network/torus-utils/result";
 import { makeErr, makeOk } from "@torus-network/torus-utils/result";
 import { tryAsync } from "@torus-network/torus-utils/try-catch";
 import { zodParseResult } from "@torus-network/torus-utils/typing";
-
+import Emittery from "emittery";
+import type { Enum } from "rustie";
+import { match } from "rustie";
+import { assert } from "tsafe";
+import { z } from "zod";
 import type { HexH256 } from "./types/index.js";
 import {
   sb_array,

--- a/packages/torus-sdk-ts/src/playground.ts
+++ b/packages/torus-sdk-ts/src/playground.ts
@@ -5,12 +5,14 @@
  *
  * Run with: npx tsx src/playground.ts
  */
-
-import { DelegationTreeManager } from "./chain/common/delegation-tree-builder.js";
+import {
+  DelegationTreeManager,
+} from "./chain/common/delegation-tree-builder.js";
 import {
   queryAgentNamespacePermissions,
-  queryEmissionPermissions,
+  queryStreamPermissions,
 } from "./chain/permission0/permission0-storage.js";
+import type { StreamContract } from "./chain/permission0/permission0-types.js";
 import type { SS58Address } from "./types/address.js";
 import { connectToChainRpc } from "./utils/index.js";
 
@@ -238,12 +240,12 @@ async function main() {
       console.log("⚠️  No test address available for delegation tree");
     }
 
-    // Test 4: Test queryEmissionPermissions
-    console.log("\n💰 Test 4: Testing queryEmissionPermissions...");
+    // Test 4: Test queryStreamPermissions
+    console.log("\n💰 Test 4: Testing queryStreamPermissions...");
 
     // Test 4.1: Get all emission permissions
     console.log("\n📋 Test 4.1: Fetching all emission permissions");
-    const [emissionError1, allEmissions] = await queryEmissionPermissions(
+    const [emissionError1, allEmissions] = await queryStreamPermissions(
       api,
       () => true, // Accept all emission permissions
     );
@@ -304,9 +306,9 @@ async function main() {
 
     // Test 4.2: Filter for specific recipient
     console.log("\n📋 Test 4.2: Filtering by recipient");
-    const [emissionError2, recipientEmissions] = await queryEmissionPermissions(
+    const [emissionError2, recipientEmissions] = await queryStreamPermissions(
       api,
-      (perm) => perm.scope.recipients.has(testAddress),
+      (perm: StreamContract) => perm.scope.recipients.has(testAddress),
     );
 
     if (emissionError2) {
@@ -319,9 +321,9 @@ async function main() {
 
     // Test 4.3: Filter for stream-based allocations
     console.log("\n📋 Test 4.3: Filtering for stream-based allocations");
-    const [emissionError3, streamEmissions] = await queryEmissionPermissions(
+    const [emissionError3, streamEmissions] = await queryStreamPermissions(
       api,
-      (perm) => "Streams" in perm.scope.allocation,
+      (perm: StreamContract) => "Streams" in perm.scope.allocation,
     );
 
     if (emissionError3) {
@@ -333,9 +335,9 @@ async function main() {
     // Test 4.4: Filter for accumulating emissions
     console.log("\n📋 Test 4.4: Filtering for accumulating emissions");
     const [emissionError4, accumulatingEmissions] =
-      await queryEmissionPermissions(
+      await queryStreamPermissions(
         api,
-        (perm) => perm.scope.accumulating === true,
+        (perm: StreamContract) => perm.scope.accumulating === true,
       );
 
     if (emissionError4) {
@@ -350,9 +352,9 @@ async function main() {
     console.log(
       "\n📋 Test 4.5: Complex filter - accumulating + manual distribution",
     );
-    const [emissionError5, complexFiltered] = await queryEmissionPermissions(
+    const [emissionError5, complexFiltered] = await queryStreamPermissions(
       api,
-      (perm) =>
+      (perm: StreamContract) =>
         perm.scope.accumulating === true && "Manual" in perm.scope.distribution,
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Stream-based permissions replace emission-based flows in create and manage forms, with multi-recipient support.
  - Per-stream allocation preview added (e.g., “allocated/total TORUS/week”) and dynamic target headers.
  - Permission selector now derives recipients from contracts and enriches permission details and search.

- Improvements
  - Enhanced total allocation calculation and loading states (“calculating...” when data unavailable).
  - UI consistency tweaks across components.

- Bug Fixes
  - Avoid passing empty grantee keys by using undefined when absent.

- Chores
  - Database migration adds recipient fields and makes grantee optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->