### PR TITLE
fix: DAO penalty consensus and reset flow

### DIFF
--- a/apps/torus-bridge/src/app/fast/_components/__tests__/fast-bridge-pending-transaction-dialog.test.tsx
+++ b/apps/torus-bridge/src/app/fast/_components/__tests__/fast-bridge-pending-transaction-dialog.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PendingTransactionDialog } from "../fast-bridge-pending-transaction-dialog";
 import { SimpleBridgeStep } from "../fast-bridge-types";
 import type { FastBridgeTransactionHistoryItem } from "../fast-bridge-types";

--- a/packages/torus-sdk-ts/src/chain/governance/governance-extrinsics.ts
+++ b/packages/torus-sdk-ts/src/chain/governance/governance-extrinsics.ts
@@ -2,6 +2,8 @@ import type { ApiPromise } from "@polkadot/api";
 import { Keyring } from "@polkadot/api";
 import { encodeAddress } from "@polkadot/util-crypto";
 import { tryAsync, trySync } from "@torus-network/torus-utils/try-catch";
+import type { TxInBlockEvent } from "../../extrinsics.js";
+import { sendTxWithTracker } from "../../extrinsics.js";
 import type { SS58Address } from "../../types/index.js";
 import type { EmissionProposal } from "./governance-types.js";
 
@@ -227,7 +229,7 @@ export async function penalizeAgent(
     throw keypairError;
   }
 
-  const [sendError, extrinsic] = await tryAsync(tx.signAndSend(sudoKeypair));
+  const [sendError, tracker] = await sendTxWithTracker(api, tx, sudoKeypair);
 
   if (sendError !== undefined) {
     console.error(
@@ -237,7 +239,60 @@ export async function penalizeAgent(
     throw sendError;
   }
 
-  return extrinsic;
+  const [finalizeError, finalizedEvent] = await tryAsync(
+    new Promise<TxInBlockEvent & { kind: "Finalized" }>((resolve, reject) => {
+      const cleanup = () => {
+        tracker.off("finalized", onFinalized);
+        tracker.off("internalError", onInternalError);
+        tracker.off("invalid", onInvalid);
+        tracker.off("finalityTimeout", onFinalityTimeout);
+      };
+
+      const onFinalized = (event: TxInBlockEvent & { kind: "Finalized" }) => {
+        cleanup();
+        resolve(event);
+      };
+
+      const onInternalError = (event: { internalError: Error }) => {
+        cleanup();
+        reject(event.internalError);
+      };
+
+      const onInvalid = (event: { reason: Error }) => {
+        cleanup();
+        reject(event.reason);
+      };
+
+      const onFinalityTimeout = () => {
+        cleanup();
+        reject(new Error("Penalize agent transaction finalization timed out"));
+      };
+
+      tracker.on("finalized", onFinalized);
+      tracker.on("internalError", onInternalError);
+      tracker.on("invalid", onInvalid);
+      tracker.on("finalityTimeout", onFinalityTimeout);
+    }),
+  );
+
+  tracker.cancel();
+
+  if (finalizeError !== undefined) {
+    console.error(
+      "Error signing and sending penalize agent transaction:",
+      finalizeError,
+    );
+    throw finalizeError;
+  }
+
+  if ("Failed" in finalizedEvent.outcome) {
+    const { error } = finalizedEvent.outcome.Failed;
+    throw new Error(
+      `Penalize agent transaction failed: ${JSON.stringify(error)}`,
+    );
+  }
+
+  return finalizedEvent.blockHash;
 }
 
 export async function denyApplication(

--- a/services/swarm-api/src/middleware/auth.ts
+++ b/services/swarm-api/src/middleware/auth.ts
@@ -69,7 +69,7 @@ export const requirePermission =
     app
       .use(authPlugin)
       .onBeforeHandle(
-        { as: "global" },
+        { as: "scoped" },
         ({ permissionCache, userKey, status }) => {
           for (const path of namespacePaths) {
             const hasPermission = permissionCache.hasPermission(userKey, path);

--- a/services/swarm-api/src/routes/claims.ts
+++ b/services/swarm-api/src/routes/claims.ts
@@ -29,8 +29,9 @@ import type {
 import { HttpError } from "../utils/errors";
 
 export const claimsRouter = (app: ContextApp) =>
-  app.use(requirePermission(["prediction.verify"])).group("/v1", (app) =>
+  app.group("/v1", (app) =>
     app
+      .use(requirePermission(["prediction.verify"]))
       .get(
         "/predictions/claimable",
         async ({ query, db, userKey }) => {

--- a/services/swarm-api/src/routes/predictions.ts
+++ b/services/swarm-api/src/routes/predictions.ts
@@ -8,7 +8,7 @@ import {
   scrapedTweetSchema,
 } from "@torus-ts/db/schema";
 import canonicalize from "canonicalize";
-import { authPlugin } from "../middleware/auth";
+import { requirePermission } from "../middleware/auth";
 import type { ContextApp } from "../middleware/context";
 import { storePredictionsInputSchema } from "../schemas/predictions";
 import { findCanonicalPrediction } from "../utils/dedup";
@@ -16,8 +16,8 @@ import type { ParsedPredictionForDedup } from "../utils/dedup";
 import { HttpError } from "../utils/errors";
 
 export const predictionsRouter = (app: ContextApp) =>
-  app.use(authPlugin).group("/v1", (app) =>
-    app.post(
+  app.group("/v1", (app) =>
+    app.use(requirePermission(["prediction.filter"])).post(
       "/storePredictions",
       async ({ body, db, serverSignHash, userKey }) => {
         const agentAddress = userKey;

--- a/services/swarm-api/src/routes/tweets.ts
+++ b/services/swarm-api/src/routes/tweets.ts
@@ -5,14 +5,14 @@ import {
   twitterScrapingJobsSchema,
   twitterUsersSchema,
 } from "@torus-ts/db/schema";
-import { authPlugin } from "../middleware/auth";
+import { requirePermission } from "../middleware/auth";
 import type { ContextApp } from "../middleware/context";
 import { getTweetsNextQuerySchema } from "../schemas/tweets";
 import { cursorSchema, encodeCursor } from "../utils/cursor";
 
 export const tweetsRouter = (app: ContextApp) =>
-  app.use(authPlugin).group("/v1", (app) =>
-    app.get(
+  app.group("/v1", (app) =>
+    app.use(requirePermission(["prediction.filter"])).get(
       "/getTweetsNext",
       async ({ query, db, userKey }) => {
         const fromData = cursorSchema.parse(query.from);

--- a/services/swarm-api/src/server.ts
+++ b/services/swarm-api/src/server.ts
@@ -9,7 +9,6 @@ import { Marked } from "marked";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { createAppContext } from "./context";
 import { getEnv } from "./env";
-import { requirePermission } from "./middleware/auth";
 import { contextPlugin } from "./middleware/context";
 import { claimsRouter } from "./routes/claims";
 import { creditsRouter } from "./routes/credits";
@@ -199,7 +198,6 @@ export async function createServer() {
     .use(permissionRouter)
     .use(creditsRouter)
     .use(claimsRouter)
-    .use(requirePermission(["prediction.filter"]))
     .use(tweetsRouter)
     .use(predictionsRouter);
 }

--- a/services/torus-worker/src/db.ts
+++ b/services/torus-worker/src/db.ts
@@ -7,7 +7,6 @@ import {
   and,
   eq,
   getTableColumns,
-  gte,
   inArray,
   isNull,
   not,
@@ -380,38 +379,49 @@ export async function countCadreKeys(): Promise<number> {
 }
 
 export async function pendingPenalizations(threshold: number, n: number) {
-  const agentsWithUnexecutedVotes = db
-    .select({ agentKey: penalizeAgentVotesSchema.agentKey })
-    .from(penalizeAgentVotesSchema)
-    .where(not(penalizeAgentVotesSchema.executed));
-
-  const result = await db
-    .with(agentsWithUnexecutedVotes.as("agents_with_unexecuted_votes"))
+  const pendingVotes = await db
     .select({
       agentKey: penalizeAgentVotesSchema.agentKey,
-      nthBiggestPenaltyFactor: sql`
-        (
-          SELECT penalty_factor
-          FROM ${penalizeAgentVotesSchema} as inner_p
-          WHERE 
-            inner_p.agent_key = ${penalizeAgentVotesSchema.agentKey}
-          ORDER BY penalty_factor DESC
-          LIMIT 1 OFFSET ${n - 1}
-        )
-      `.as<number>(),
+      penaltyFactor: penalizeAgentVotesSchema.penaltyFactor,
     })
     .from(penalizeAgentVotesSchema)
     .where(
-      sql`${penalizeAgentVotesSchema.agentKey} in (select "agent_key" from agents_with_unexecuted_votes)`,
+      and(
+        isNull(penalizeAgentVotesSchema.deletedAt),
+        not(penalizeAgentVotesSchema.executed),
+      ),
     )
-    .groupBy(penalizeAgentVotesSchema.agentKey)
-    .having(gte(sql`count(*)`, threshold));
+    .execute();
 
-  const castedResult = result.map((row) => ({
-    agentKey: checkSS58(row.agentKey),
-    nthBiggestPenaltyFactor: row.nthBiggestPenaltyFactor,
-  }));
-  return castedResult;
+  const factorsByAgent = new Map<string, number[]>();
+  for (const vote of pendingVotes) {
+    const factors = getOrSetDefault(factorsByAgent, vote.agentKey, () => []);
+    factors.push(vote.penaltyFactor);
+  }
+
+  const result: {
+    agentKey: SS58Address;
+    nthBiggestPenaltyFactor: number;
+  }[] = [];
+
+  for (const [agentKey, factors] of factorsByAgent) {
+    if (factors.length < threshold) {
+      continue;
+    }
+
+    const sortedFactors = [...factors].sort((a, b) => b - a);
+    const selectedFactor = sortedFactors[Math.max(n - 1, 0)];
+    if (selectedFactor === undefined) {
+      continue;
+    }
+
+    result.push({
+      agentKey: checkSS58(agentKey),
+      nthBiggestPenaltyFactor: selectedFactor,
+    });
+  }
+
+  return result;
 }
 
 export async function getAgentKeysWithPenalties() {
@@ -421,7 +431,7 @@ export async function getAgentKeysWithPenalties() {
       count: sql`count(*)`.as<number>(),
     })
     .from(penalizeAgentVotesSchema)
-    .where(not(penalizeAgentVotesSchema.executed))
+    .where(isNull(penalizeAgentVotesSchema.deletedAt))
     .groupBy(penalizeAgentVotesSchema.agentKey)
     .execute();
 

--- a/services/torus-worker/src/workers/process-dao-applications.ts
+++ b/services/torus-worker/src/workers/process-dao-applications.ts
@@ -94,8 +94,6 @@ export async function processApplicationsWorker(props: WorkerProps) {
     );
   }
 
-  let evenIteration = true;
-
   while (true) {
     const workerRes = await tryAsync(
       (async () => {
@@ -155,28 +153,42 @@ export async function processApplicationsWorker(props: WorkerProps) {
 
         log.info(`Penalty threshold: ${penaltyVoteThreshold}`);
 
-        let factors: {
+        const factorsToApply: {
           agentKey: SS58Address;
           nthBiggestPenaltyFactor: number;
         }[] = [];
 
-        if (evenIteration) {
-          log.info("Even iteration: processing penalty factors");
-          const factorsRes = await tryAsync(
-            getPenaltyFactors(penaltyVoteThreshold),
-          );
-          if (log.ifResultIsErr(factorsRes)) return;
-          const [_factorsErr, penaltyFactors] = factorsRes;
-          factors = penaltyFactors;
-        } else {
-          log.info("Odd iteration: checking for keys to reset");
-          const keysResetRes = await tryAsync(
-            getKeysToReset(props.api, penaltyVoteThreshold),
-          );
-          if (log.ifResultIsErr(keysResetRes)) return;
-          const [_keysResetErr, keysResetToPenaltyZero] = keysResetRes;
-          factors = keysResetToPenaltyZero;
+        const factorsRes = await tryAsync(
+          getPenaltyFactors(penaltyVoteThreshold),
+        );
+        if (log.ifResultIsErr(factorsRes)) return;
+        const [_factorsErr, penaltyFactors] = factorsRes;
+        factorsToApply.push(...penaltyFactors);
+
+        const keysResetRes = await tryAsync(
+          getKeysToReset(props.api, penaltyVoteThreshold),
+        );
+        if (log.ifResultIsErr(keysResetRes)) return;
+        const [_keysResetErr, keysResetToPenaltyZero] = keysResetRes;
+
+        const factorByAgentKey = new Map<SS58Address, number>();
+        for (const factor of factorsToApply) {
+          factorByAgentKey.set(factor.agentKey, factor.nthBiggestPenaltyFactor);
         }
+        for (const factor of keysResetToPenaltyZero) {
+          if (!factorByAgentKey.has(factor.agentKey)) {
+            factorByAgentKey.set(
+              factor.agentKey,
+              factor.nthBiggestPenaltyFactor,
+            );
+          }
+        }
+        const factors = Array.from(factorByAgentKey.entries()).map(
+          ([agentKey, nthBiggestPenaltyFactor]) => ({
+            agentKey,
+            nthBiggestPenaltyFactor,
+          }),
+        );
 
         if (factors.length === 0) {
           log.info("No penalty changes needed");
@@ -195,8 +207,6 @@ export async function processApplicationsWorker(props: WorkerProps) {
     if (log.ifResultIsErr(workerRes)) {
       await sleep(retryDelay);
     }
-
-    evenIteration = !evenIteration;
   }
 }
 
@@ -386,14 +396,11 @@ async function getPenaltyFactors(cadreThreshold: number) {
 }
 
 /**
- * Identifies agents with active penalties that should be reset to zero
- * because their penalty votes have fallen below the required threshold.
- *
- * Compares on-chain penalty state with current vote counts to identify
- * candidates for penalty removal.
+ * Identifies agents with active on-chain penalties that should be reset to zero
+ * because their vote support has dropped below the required threshold.
  *
  * @param api - Polkadot API instance for querying current agent state
- * @param penaltyThreshold - Minimum votes needed to maintain a penalty
+ * @param penaltyThreshold - Minimum votes needed to keep a non-zero penalty
  * @returns List of agents whose penalties should be reset to zero
  */
 async function getKeysToReset(api: ApiPromise, penaltyThreshold: number) {
@@ -403,7 +410,6 @@ async function getKeysToReset(api: ApiPromise, penaltyThreshold: number) {
   );
 
   const agentsMap = await queryAgents(api);
-
   const keysToResetPenalty: {
     agentKey: SS58Address;
     nthBiggestPenaltyFactor: number;
@@ -411,14 +417,14 @@ async function getKeysToReset(api: ApiPromise, penaltyThreshold: number) {
 
   for (const [agentKey, agent] of agentsMap) {
     const hasCurrentPenalty = agent.weightPenaltyFactor > 0;
-    const voteCount = voteCountByAgentKey.get(agentKey) ?? 0;
+    if (!hasCurrentPenalty) {
+      continue;
+    }
 
-    if (hasCurrentPenalty && voteCount < penaltyThreshold) {
-      log.info(
-        `Agent ${agentKey}: resetting penalty (${voteCount} votes < ${penaltyThreshold} threshold)`,
-      );
+    const voteCount = voteCountByAgentKey.get(agentKey) ?? 0;
+    if (voteCount < penaltyThreshold) {
       keysToResetPenalty.push({
-        agentKey: agentKey,
+        agentKey,
         nthBiggestPenaltyFactor: 0,
       });
     }
@@ -454,7 +460,6 @@ async function processPenalty(
   if (log.ifResultIsErr(agentsRes, agentsErrorMsg)) return;
   const [_agentsErr, agentsMap] = agentsRes;
 
-  const allProcessedKeys: SS58Address[] = [];
   const DELAY_BETWEEN_TXS = 10000; // 10 second delay between transactions
 
   log.info(
@@ -471,6 +476,9 @@ async function processPenalty(
     }
 
     if (nthBiggestPenaltyFactor !== agent.weightPenaltyFactor) {
+      const isLastPenalty =
+        penalty === penaltiesToApply[penaltiesToApply.length - 1];
+
       log.info(
         `Applying penalty ${nthBiggestPenaltyFactor}% to ${agentKey} (was ${agent.weightPenaltyFactor}%)`,
       );
@@ -481,27 +489,37 @@ async function processPenalty(
 
       const penalizeErrorMsg = () =>
         `Failed to apply penalty to agent ${agentKey}:`;
-      if (log.ifResultIsErr(penalizeRes, penalizeErrorMsg)) continue;
+      if (log.ifResultIsErr(penalizeRes, penalizeErrorMsg)) {
+        // Keep spacing between failed attempts to avoid tx pool replacement churn.
+        if (!isLastPenalty) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, DELAY_BETWEEN_TXS),
+          );
+        }
+        continue;
+      }
+
+      const markExecutedRes = await tryAsync(
+        updatePenalizeAgentVotes([agentKey]),
+      );
+      const markExecutedErrorMsg = () =>
+        `Failed to mark penalty votes as executed for ${agentKey}:`;
+      if (log.ifResultIsErr(markExecutedRes, markExecutedErrorMsg)) {
+        if (!isLastPenalty) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, DELAY_BETWEEN_TXS),
+          );
+        }
+        continue;
+      }
 
       log.info(`✅ Applied penalty ${nthBiggestPenaltyFactor}% to ${agentKey}`);
-      allProcessedKeys.push(agentKey);
+      log.info(`✅ Marked penalty votes as executed for ${agentKey}`);
 
       // Add delay between transactions to avoid "priority too low" errors
-      if (penalty !== penaltiesToApply[penaltiesToApply.length - 1]) {
+      if (!isLastPenalty) {
         await new Promise((resolve) => setTimeout(resolve, DELAY_BETWEEN_TXS));
       }
     }
-  }
-
-  if (allProcessedKeys.length > 0) {
-    const updateRes = await tryAsync(
-      updatePenalizeAgentVotes(allProcessedKeys),
-    );
-    const updateErrorMsg = () => "Failed to update penalty votes:";
-    if (log.ifResultIsErr(updateRes, updateErrorMsg)) return;
-
-    log.info(`✅ Marked ${allProcessedKeys.length} penalty votes as executed`);
-  } else {
-    log.info("No penalty updates needed");
   }
 }


### PR DESCRIPTION
## What was wrong
  - Penalty factor selection was wrong: it could return 100 even when pending votes were 20.
  - Penalty processing flip-flopped between apply/reset due to alternating iteration logic.
  - Penalty tx flow didn’t wait for finalization.
  - One lint warning in torus-bridge test (afterEach unused).
  ## What changed
  - Rewrote pendingPenalizations to compute factor from the actual pending vote set (executed=false, deleted_at IS NULL)
    and select nth-highest deterministically.
  - Restored reset-to-0 logic, but made it correct:
      - reset only if on-chain penalty >0 and active vote support is below threshold.
  - Removed odd/even toggle; now apply+reset candidates are computed each cycle and merged once.
  - Updated penalizeAgent to use tx tracker and wait for finalized before success.
  - Removed unused afterEach import in bridge test.