### PR TITLE
ci: stop auto-deploying to decommissioned k8s cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Apps Deployment
 
+# 2026-07-08: k8s cluster (DO renlabs-cluster) decommissioned. Frontends ship
+# via Vercel (torus-portal, torus-wallet, torus-bridge-v2, torus-blog);
+# torus-cache runs on api-0. Pipeline kept for reference - manual trigger only.
 on:
   workflow_dispatch:
     inputs:
@@ -8,13 +11,6 @@ on:
         description: "Skip Docker Build"
         type: boolean
         default: false
-  push:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - closed
-      - synchronize
 
 permissions: write-all
 


### PR DESCRIPTION
## What

Removes the `push` and `pull_request` triggers from the Apps Deployment workflow, keeping `workflow_dispatch` for reference. Without this every push/PR fails trying to helmfile-sync against a cluster that no longer exists.

## Context

The DO `renlabs-cluster` was decommissioned on 2026-07-08 as part of infra minimization:
- Frontends (torus.network LP/portal, wallet) now ship via Vercel Git integration — same as bridge-v2 and blog already did
- `torus-cache` runs on api-0 next to the node it reads from
- prometheus/loki/grafana replaced by uptime-kuma + Discord alerts

## Notes for follow-up (separate PRs)
- `packages/torus-sdk-ts/src/evm.ts` re-exports `waitForTransactionReceipt` from `@wagmi/core` without declaring the dependency — any cold build of a pruned workspace that includes the sdk fails (`TS2307`); CI only passes via turbo remote cache hits. Fix: add `@wagmi/core` to the sdk's deps.
- Shared UI still hard-links `dao.torus.network` and `docs.torus.network`, which are now offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)